### PR TITLE
Remove stale Netlify references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Copy this file to .env.local and fill in your values
-VITE_APP_URL=https://your-deployed-url.netlify.app
+VITE_APP_URL=https://your-app.pages.dev
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 VITE_NEWSAPI_KEY=

--- a/src/services/guardian.ts
+++ b/src/services/guardian.ts
@@ -404,7 +404,7 @@ class GuardianService {
     // Use the app's base URL - must be set in environment variables
     const baseUrl = import.meta.env.VITE_APP_URL;
     if (!baseUrl) {
-      throw new Error('VITE_APP_URL environment variable is not set. Please set it to your app\'s domain (e.g., https://hyperap.netlify.app)');
+      throw new Error('VITE_APP_URL environment variable is not set. Please set it to your app\'s public domain (e.g., https://your-app.pages.dev)');
     }
     const invitationUrl = `${baseUrl}/guardian/invite/${invitation.invitation_token}`;
 


### PR DESCRIPTION
Removes the remaining Netlify URLs from the environment template and guardian invitation configuration message. Cloudflare Pages remains the documented hosting target.