### PR TITLE
Deploy current HyperApp dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,10 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Capacitor } from '@capacitor/core';
 import { Box, Text as ChakraText } from '@chakra-ui/react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Sparkles } from 'lucide-react';
 
 import { useAuth } from './contexts/AuthContext';
 import { useNotification } from './contexts/NotificationContext';
-import { LanguageProvider, useLanguage } from './contexts/LanguageContext';
+import { LanguageProvider } from './contexts/LanguageContext';
 import { VibeProvider } from './contexts/VibeContext';
 import { SettingsProvider, useSettings } from './contexts/SettingsContext';
 import { NotificationManager } from './components/shared/Notification';
@@ -19,7 +18,6 @@ import MagicLinkAuth from './components/MagicLinkAuth';
 import GuardianInvitationHandler from './components/GuardianInvitationHandler';
 import ReportTypeModal from './components/ReportTypeModal';
 import SplashScreen from './components/SplashScreen';
-import LanguageSelectionScreen from './components/LanguageSelectionScreen';
 import ErrorBoundary from './components/ErrorBoundary';
 import { LoadingSpinner } from './components/shared';
 import { reportsService } from './services/reports';
@@ -30,45 +28,42 @@ import { pushNotificationService } from './services/pushNotificationService';
 import { locationService } from './services/locationService';
 import { logger } from './lib/logger';
 import type { Vibe, SOS } from './types';
+import './styles/appShell.css';
 
 // Lazy load heavy components for better performance
 const MapComponent = React.lazy(() => import('./components/MapComponent'));
 const ProfileView = React.lazy(() => import('./components/ProfileView'));
 const SettingsView = React.lazy(() => import('./components/SettingsView'));
 const CommunityDashboard = React.lazy(() => import('./components/CommunityDashboard'));
-const GuardianView = React.lazy(() => import('./components/GuardianView'));
-const HubView = React.lazy(() => import('./components/HubView'));
+const DashboardView = React.lazy(() => import('./components/DashboardView'));
 
 // Additional lazy loading for even better performance
-const EditProfileModal = React.lazy(() => import('./components/EditProfileModal'));
 const EmergencyReportModal = React.lazy(() => import('./components/EmergencyReportModal'));
 const VibeReportModal = React.lazy(() => import('./components/VibeReportModal'));
 const LocationOverrideModal = React.lazy(() => import('./components/LocationOverrideModal'));
 const LocationPermissionModal = React.lazy(() => import('./components/LocationPermissionModal'));
 const GuardianEmergencyModal = React.lazy(() => import('./components/GuardianEmergencyModal'));
-const VoiceChatModal = React.lazy(() => import('./components/VoiceChatModal'));
 
 
 const AppContent: React.FC = () => {
   console.log('🎯 AppContent component rendering...');
-  const { user, isAuthenticated, isLoading, updateProfile } = useAuth();
-  const { currentLanguage } = useLanguage();
+  const { user, isAuthenticated, isLoading } = useAuth();
   const { notifications, removeNotification, addNotification, markAsRead, markAllAsRead, clearAll } = useNotification();
   const { settings } = useSettings();
   console.log('📊 AppContent state:', { isAuthenticated, isLoading, user: !!user });
-  const [activeTab, setActiveTab] = useState<TabType>('map');
+  const [activeTab, setActiveTab] = useState<TabType>('dashboard');
+  const contentScrollRef = useRef<HTMLDivElement>(null);
   const [vibes, setVibes] = useState<Vibe[]>([]);
   const [sosAlerts, setSosAlerts] = useState<SOS[]>([]);
   const [nearbyUsers, setNearbyUsers] = useState<NearbyUser[]>([]);
   const [userLocation, setUserLocation] = useState<[number, number] | null>(null);
+  const [initialCenter, setInitialCenter] = useState<[number, number] | null>(null);
   const [dataLoaded, setDataLoaded] = useState(false);
   const [isHeatmapVisible, setIsHeatmapVisible] = useState(true);
   const [showAuthModal, setShowAuthModal] = useState(false);
-  const [showLanguageSelection, setShowLanguageSelection] = useState(false);
   const [showReportTypeModal, setShowReportTypeModal] = useState(false);
   const [showVibeReportModal, setShowVibeReportModal] = useState(false);
   const [showEmergencyReportModal, setShowEmergencyReportModal] = useState(false);
-  const [showVoiceChatModal, setShowVoiceChatModal] = useState(false);
   const [showLocationOverride, setShowLocationOverride] = useState(false);
 
   const [locationInitialized, setLocationInitialized] = useState(false);
@@ -76,24 +71,24 @@ const AppContent: React.FC = () => {
   const [targetLocation, setTargetLocation] = useState<[number, number] | null>(null);
   const [locationPermissionStatus, setLocationPermissionStatus] = useState<'granted' | 'denied' | 'prompt' | 'unknown'>('unknown');
   const [showLocationPermissionModal, setShowLocationPermissionModal] = useState(false);
+
+  useEffect(() => {
+    contentScrollRef.current?.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+  }, [activeTab]);
   const [locationRefreshInterval, setLocationRefreshInterval] = useState<NodeJS.Timeout | null>(null);
   const [nearbyUsersRefreshInterval, setNearbyUsersRefreshInterval] = useState<NodeJS.Timeout | null>(null);
   const [lastLocationUpdate, setLastLocationUpdate] = useState<number>(0);
   const [lastNearbyUsersUpdate, setLastNearbyUsersUpdate] = useState<number>(0);
 
-  // Default center (Cairo, Egypt)
-  const center: [number, number] = [30.0444, 31.2357];
+  // Wait for the device's current location before rendering the map.
   const zoom = 10;
 
-  // Show language selection for non-authenticated users
+  // Open authentication directly now that English is the only supported language.
   useEffect(() => {
-    console.log('🔍 Language selection check:', { isLoading, isAuthenticated, user: !!user, onboardingCompleted: user?.onboarding_completed });
     if (!isLoading && !isAuthenticated) {
-      // Always show language selection for non-authenticated users
-      console.log('🌐 Showing language selection for non-authenticated user');
-      setShowLanguageSelection(true);
+      setShowAuthModal(true);
     }
-  }, [isLoading, isAuthenticated, user?.onboarding_completed]);
+  }, [isLoading, isAuthenticated]);
 
   // Handle post-authentication redirects (e.g., from guardian invitations)
   useEffect(() => {
@@ -228,6 +223,7 @@ const AppContent: React.FC = () => {
             const location: [number, number] = [position.latitude, position.longitude];
             console.log('✅ GPS location obtained:', location);
             setUserLocation(location);
+            setInitialCenter((current) => current ?? location);
             setLastLocationUpdate(Date.now());
             console.log(`📍 GPS location set: ${position.latitude.toFixed(6)}, ${position.longitude.toFixed(6)} (${Math.round(position.accuracy)}m)`);
             console.log('🎯 User location state should now be set - marker should appear on map');
@@ -292,67 +288,9 @@ const AppContent: React.FC = () => {
             // Check if this is a permission-related error
             const isPermissionError = (error as any)?.code === 1 || (error as any)?.message?.toLowerCase().includes('permission');
 
-            // Always try IP-based fallback for better UX
-            console.log('🔄 GPS failed, trying fallback methods...');
-            if (!Capacitor.isNativePlatform()) {
-              try {
-                console.log('🌐 Attempting IP-based geolocation fallback...');
-                // Use IP geolocation as fallback
-                const response = await fetch('https://ipapi.co/json/');
-                console.log('🌐 IP API response status:', response.status);
-                const data = await response.json();
-                console.log('🌐 IP API response data:', data);
+            console.log('GPS failed and no fallback will be used. Waiting for a real current-location fix.');
 
-                if (data.latitude && data.longitude) {
-                  const location: [number, number] = [data.latitude, data.longitude];
-                  console.log('✅ Setting IP location:', location);
-                  setUserLocation(location);
-                  console.log(`📍 IP Location fallback successful: ${data.latitude}, ${data.longitude} (${data.city || 'Unknown'}) - marker should appear`);
-                } else {
-                  console.log('❌ IP API returned invalid data:', data);
-                  throw new Error('Invalid IP geolocation response');
-                }
-              } catch (ipError: any) {
-                console.log('❌ IP geolocation fallback failed:', ipError instanceof Error ? ipError.message : ipError);
-                // Use default location as last resort
-                const defaultLocation: [number, number] = [30.0444, 31.2357]; // Cairo, Egypt
-                console.log('✅ Setting default location:', defaultLocation);
-                setUserLocation(defaultLocation);
-                console.log(`📍 Using default location: ${defaultLocation[0]}, ${defaultLocation[1]} - marker should appear on map`);
-              }
-            } else {
-              // On mobile, try IP fallback too
-              try {
-                console.log('📱 Mobile: Attempting IP-based geolocation fallback...');
-                const response = await fetch('https://ipapi.co/json/');
-                console.log('📱 Mobile IP API response status:', response.status);
-                const data = await response.json();
-                console.log('📱 Mobile IP API response data:', data);
-
-                if (data.latitude && data.longitude) {
-                  const location: [number, number] = [data.latitude, data.longitude];
-                  console.log('✅ Setting mobile IP location:', location);
-                  setUserLocation(location);
-                  console.log(`📍 Mobile IP Location fallback: ${data.latitude}, ${data.longitude} - marker should appear`);
-                } else {
-                  // Use default for mobile too
-                  const defaultLocation: [number, number] = [30.0444, 31.2357];
-                  logger.log('✅ Setting mobile default location:', defaultLocation);
-                  setUserLocation(defaultLocation);
-                  logger.log(`📍 Mobile using default location: ${defaultLocation[0]}, ${defaultLocation[1]} - marker should appear`);
-                }
-              } catch (mobileError) {
-                logger.log('❌ Mobile IP fallback failed:', (mobileError as Error)?.message || mobileError);
-                // Still show permission modal for mobile
-                if (isPermissionError) {
-                  logger.log('🚨 Showing permission modal for mobile due to permission error');
-                  setShowLocationPermissionModal(true);
-                }
-              }
-            }
-
-            // Show permission modal on web if it was a permission error
-            if (!Capacitor.isNativePlatform() && isPermissionError) {
+            if (isPermissionError) {
               setShowLocationPermissionModal(true);
             }
           }
@@ -685,32 +623,6 @@ const AppContent: React.FC = () => {
     setShowAuthModal(false);
   };
 
-  const handleLanguageSelect = async (language: 'en' | 'ar') => {
-    // Set language in localStorage
-    localStorage.setItem('language', language);
-
-    // Update i18n language directly
-    const i18n = (await import('./i18n')).default;
-    await i18n.changeLanguage(language);
-
-    // Set document direction and language
-    const direction = language === 'ar' ? 'rtl' : 'ltr';
-    document.documentElement.dir = direction;
-    document.documentElement.lang = language;
-
-    if (language === 'ar') {
-      document.body.classList.add('rtl');
-    } else {
-      document.body.classList.remove('rtl');
-    }
-
-    // Hide language selection and show auth modal
-    setShowLanguageSelection(false);
-    setShowAuthModal(true);
-  };
-
-
-
   const handleNewReport = () => {
     setShowReportTypeModal(true);
   };
@@ -808,22 +720,41 @@ const AppContent: React.FC = () => {
 
     const view = (() => {
       switch (activeTab) {
+      case 'dashboard':
+        return (
+          <ErrorBoundary>
+            <React.Suspense fallback={<LoadingFallback />}>
+              <DashboardView
+                vibes={vibes}
+                sosAlerts={sosAlerts}
+                userLocation={userLocation}
+                onNewReport={handleNewReport}
+                onNavigate={setActiveTab}
+                onNavigateToMap={handleNavigateToMap}
+              />
+            </React.Suspense>
+          </ErrorBoundary>
+        );
       case 'map':
         return (
           <ErrorBoundary>
             <React.Suspense fallback={<LoadingFallback />}>
-              <MapComponent
-                vibes={vibes}
-                sosAlerts={sosAlerts}
-                center={center}
-                zoom={zoom}
-                userLocation={userLocation}
-                nearbyUsers={nearbyUsers}
-                isHeatmapVisible={isHeatmapVisible}
-                onToggleHeatmap={handleToggleHeatmap}
-                userId={user?.id || 'demo-user'}
-                targetLocation={targetLocation}
-              />
+              {!initialCenter ? (
+                <LoadingFallback />
+              ) : (
+                <MapComponent
+                  vibes={vibes}
+                  sosAlerts={sosAlerts}
+                  center={initialCenter}
+                  zoom={zoom}
+                  userLocation={userLocation}
+                  nearbyUsers={nearbyUsers}
+                  isHeatmapVisible={isHeatmapVisible}
+                  onToggleHeatmap={handleToggleHeatmap}
+                  userId={user?.id || 'demo-user'}
+                  targetLocation={targetLocation}
+                />
+              )}
             </React.Suspense>
           </ErrorBoundary>
         );
@@ -850,22 +781,6 @@ const AppContent: React.FC = () => {
             </React.Suspense>
           </ErrorBoundary>
         );
-      case 'hub':
-        return (
-          <ErrorBoundary>
-            <React.Suspense fallback={<LoadingFallback />}>
-              <HubView userLocation={userLocation} />
-            </React.Suspense>
-          </ErrorBoundary>
-        );
-      case 'guardian':
-        return (
-          <ErrorBoundary>
-            <React.Suspense fallback={<LoadingFallback />}>
-              <GuardianView />
-            </React.Suspense>
-          </ErrorBoundary>
-        );
       case 'settings':
         return (
           <ErrorBoundary>
@@ -888,9 +803,11 @@ const AppContent: React.FC = () => {
           exit="out"
           variants={pageVariants}
           transition={pageTransition}
-          style={{ height: '100%', width: '100%' }}
+          style={{ height: '100%', width: '100%', minWidth: 0 }}
         >
-          {view}
+          <div className={activeTab === 'map' ? 'app-content-shell app-content-shell--map' : 'app-content-shell'}>
+            {view}
+          </div>
         </motion.div>
       </AnimatePresence>
     );
@@ -898,7 +815,6 @@ const AppContent: React.FC = () => {
 
   return (
     <div
-      key={currentLanguage}
       className="app-layout"
       style={{ backgroundColor: 'var(--bg-base)', overflowX: 'hidden' }}
     >
@@ -910,8 +826,8 @@ const AppContent: React.FC = () => {
             onNewReport={handleNewReport}
           />
           <div className="app-main">
-            <Header onNavigateToProfile={() => setActiveTab('profile')} />
-            <div className="app-content-desktop">
+            <Header />
+            <div ref={contentScrollRef} className="app-content-desktop">
               {renderActiveView()}
             </div>
           </div>
@@ -920,33 +836,7 @@ const AppContent: React.FC = () => {
             onTabChange={setActiveTab}
             onNewReport={handleNewReport}
           />
-          <button
-            type="button"
-            className="hyper-ai-launcher"
-            onClick={() => setShowVoiceChatModal(true)}
-            aria-label="Open Hyper AI voice assistant"
-          >
-            <Sparkles size={19} aria-hidden="true" />
-            <span>Hyper AI</span>
-          </button>
         </>
-      )}
-
-      {showVoiceChatModal && (
-        <React.Suspense fallback={null}>
-          <VoiceChatModal
-            isOpen
-            onClose={() => setShowVoiceChatModal(false)}
-            userLocation={userLocation}
-          />
-        </React.Suspense>
-      )}
-
-      {/* Language Selection Screen */}
-      {showLanguageSelection && (
-        <LanguageSelectionScreen
-          onLanguageSelect={handleLanguageSelect}
-        />
       )}
 
       {/* Auth Modal */}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { Map, Users, Activity, Shield, User, Settings, Plus } from 'lucide-react';
+import { LayoutDashboard, Map, Plus, Settings, User, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+
+import { useAuth } from '../contexts/AuthContext';
+
+import NotificationBell from './shared/NotificationBell';
 import { TabType } from './TabNavigation';
 
+/* eslint-disable no-unused-vars -- the legacy base rule misreads TypeScript callback signatures */
 interface AppSidebarProps {
   activeTab: TabType;
   onTabChange: (tab: TabType) => void;
@@ -10,73 +15,68 @@ interface AppSidebarProps {
 }
 
 const tabs = [
-  { id: 'map' as TabType,      icon: Map,      labelKey: 'tabs.map'      },
-  { id: 'reports' as TabType,  icon: Users,    labelKey: 'tabs.community' },
-  { id: 'hub' as TabType,      icon: Activity, labelKey: 'tabs.hub'      },
-  { id: 'guardian' as TabType, icon: Shield,   labelKey: 'tabs.guardian' },
-  { id: 'profile' as TabType,  icon: User,     labelKey: 'tabs.profile'  },
+  { id: 'dashboard' as TabType, icon: LayoutDashboard, labelKey: 'tabs.dashboard' },
+  { id: 'map' as TabType, icon: Map, labelKey: 'tabs.map' },
+  { id: 'reports' as TabType, icon: Users, labelKey: 'tabs.community' },
+  { id: 'profile' as TabType, icon: User, labelKey: 'tabs.profile' },
   { id: 'settings' as TabType, icon: Settings, labelKey: 'tabs.settings' },
 ];
 
 const AppSidebar: React.FC<AppSidebarProps> = ({ activeTab, onTabChange, onNewReport }) => {
   const { t } = useTranslation();
+  const { user } = useAuth();
+  const userName = user?.first_name || user?.username || t('dashboard.neighbour', 'Neighbour');
+  const userInitial = String(userName).charAt(0).toUpperCase();
 
   return (
-    <nav className="app-sidebar" aria-label="Main navigation">
-      {/* Logo */}
-      <div style={{ display:'flex', alignItems:'center', gap:'10px', marginBottom:'32px', padding:'0 8px' }}>
-        <div style={{
-          width:'34px', height:'34px', borderRadius:'10px',
-          background:'linear-gradient(135deg,#00c896,#4f8ef7)',
-          display:'flex', alignItems:'center', justifyContent:'center', flexShrink:0
-        }}>
-          <div style={{ width:'14px', height:'14px', background:'rgba(9,9,11,0.5)', clipPath:'polygon(50% 0%,100% 25%,100% 75%,50% 100%,0% 75%,0% 25%)' }} />
+    <nav className="app-sidebar" aria-label={t('app.mainNavigation', 'Main navigation')}>
+      <div className="app-sidebar__top">
+        <div className="app-sidebar__brand">
+          <span className="app-sidebar__brand-mark" aria-hidden="true"><span /></span>
+          <div>
+            <strong>HyperApp</strong>
+            <span>{t('app.communitySafety', 'Community safety')}</span>
+          </div>
         </div>
-        <span style={{ fontSize:'17px', fontWeight:'800', color:'var(--t1)', letterSpacing:'-0.4px' }}>HyperApp</span>
+        <NotificationBell tone="dark" />
       </div>
 
-      {/* Nav items */}
-      <div style={{ display:'flex', flexDirection:'column', gap:'2px', flex:1 }}>
+      <div className="app-sidebar__status">
+        <span aria-hidden="true" />
+        {t('app.liveNetwork', 'Live network')}
+      </div>
+
+      <div className="app-sidebar__nav">
         {tabs.map(({ id, icon: Icon, labelKey }) => {
           const isActive = activeTab === id;
           return (
             <button
               key={id}
+              type="button"
               onClick={() => onTabChange(id)}
-              style={{
-                display:'flex', alignItems:'center', gap:'12px',
-                padding:'10px 12px', borderRadius:'var(--r-md)',
-                background: isActive ? 'var(--accent-dim)' : 'transparent',
-                border: isActive ? '0.5px solid rgba(0,200,150,0.2)' : '0.5px solid transparent',
-                color: isActive ? 'var(--accent)' : 'var(--t2)',
-                fontSize:'14px', fontWeight: isActive ? '600' : '400',
-                cursor:'pointer', width:'100%', textAlign:'left',
-                transition:'all 0.15s',
-              }}
-              onMouseEnter={e => { if (!isActive) (e.currentTarget as HTMLButtonElement).style.background = 'var(--glass)'; }}
-              onMouseLeave={e => { if (!isActive) (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+              className={isActive ? 'app-sidebar__nav-item is-active' : 'app-sidebar__nav-item'}
+              aria-current={isActive ? 'page' : undefined}
             >
-              <Icon size={18} style={{ flexShrink:0 }} />
+              <span className="app-sidebar__nav-icon"><Icon size={18} /></span>
               <span>{t(labelKey, id)}</span>
             </button>
           );
         })}
       </div>
 
-      {/* FAB */}
-      <button
-        onClick={onNewReport}
-        style={{
-          display:'flex', alignItems:'center', justifyContent:'center', gap:'8px',
-          width:'100%', padding:'12px', borderRadius:'var(--r-md)',
-          background:'var(--accent)', color:'var(--accent-text)',
-          border:'none', cursor:'pointer', fontSize:'14px', fontWeight:'700',
-          marginTop:'16px', boxShadow:'0 4px 16px rgba(0,200,150,0.3)',
-        }}
-      >
-        <Plus size={18} />
-        <span>{t('app.newReport', 'New Report')}</span>
-      </button>
+      <div className="app-sidebar__footer">
+        <div className="app-sidebar__identity">
+          <span>{userInitial}</span>
+          <div>
+            <strong>{userName}</strong>
+            <small>{t('app.communityMember', 'Community member')}</small>
+          </div>
+        </div>
+        <button type="button" className="app-sidebar__create" onClick={onNewReport}>
+          <Plus size={17} />
+          <span>{t('app.newReport', 'New report')}</span>
+        </button>
+      </div>
     </nav>
   );
 };

--- a/src/components/AuthModal.test.tsx
+++ b/src/components/AuthModal.test.tsx
@@ -66,7 +66,7 @@ describe('AuthModal', () => {
       </TestWrapper>,
     );
 
-    expect(screen.getByText('auth.login')).toBeInTheDocument();
+    expect(screen.getAllByText('auth.login')).toHaveLength(2);
     expect(screen.getByText('auth.signup')).toBeInTheDocument();
     expect(screen.getByText('auth.email')).toBeInTheDocument();
     expect(screen.getByText('auth.password')).toBeInTheDocument();

--- a/src/components/CommunityDashboard.tsx
+++ b/src/components/CommunityDashboard.tsx
@@ -499,15 +499,16 @@ const CommunityDashboard: React.FC<CommunityDashboardProps> = ({
   }
 
   return (
-    <Box maxW="500px" mx="auto" bg="var(--bg-base)" minH="100vh" position="relative" borderX="1px solid" borderColor="var(--wire)" style={{ color: 'var(--t1)' }}>
+    <Box className="page-view page-view--community" maxW="920px" w="full" mx="auto" bg="var(--bg-base)" minH="100%" position="relative" borderX="1px solid" borderColor="var(--wire)" style={{ color: 'var(--t1)' }}>
       {/* Header */}
       <Box
+        className="page-view__header"
         bg="var(--bg-surface)"
         color="var(--t1)"
         p={6}
         position="sticky"
         top={0}
-        zIndex={100}
+        zIndex={20}
         borderBottom="1px solid"
         borderColor="gray.200"
         boxShadow="0 1px 3px rgba(0, 0, 0, 0.05)"

--- a/src/components/DashboardView.css
+++ b/src/components/DashboardView.css
@@ -1,0 +1,1080 @@
+.dashboard-view {
+  --dashboard-glass-border: rgba(255, 255, 255, 0.78);
+  --dashboard-glass-shadow: 0 20px 54px rgba(15, 23, 42, 0.09), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  --dashboard-glass-blur: blur(22px) saturate(145%);
+  position: relative;
+  min-height: 100%;
+  padding: clamp(2px, 0.7vw, 10px);
+  isolation: isolate;
+}
+
+.dashboard-view::before {
+  content: '';
+  position: absolute;
+  inset: -36px;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 5% 12%, rgba(255, 255, 255, 0.98) 0 8%, transparent 34%),
+    radial-gradient(ellipse at 88% 4%, rgba(172, 204, 192, 0.48) 0 6%, transparent 29%),
+    radial-gradient(ellipse at 77% 91%, rgba(255, 255, 255, 0.9) 0 9%, transparent 36%),
+    radial-gradient(circle at 34% 75%, rgba(208, 220, 214, 0.5), transparent 29%),
+    repeating-radial-gradient(ellipse at 10% 80%, rgba(20, 24, 28, 0.028) 0 2px, transparent 3px 20px);
+  filter: blur(2px) saturate(115%);
+  opacity: 0.96;
+}
+
+.dashboard-view::after {
+  content: '';
+  position: absolute;
+  top: clamp(30px, 8vw, 110px);
+  right: clamp(-90px, -4vw, -30px);
+  z-index: -1;
+  width: clamp(210px, 27vw, 410px);
+  aspect-ratio: 1;
+  border: 1px solid rgba(255, 255, 255, 0.62);
+  border-radius: 38% 62% 58% 42% / 45% 40% 60% 55%;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.66), rgba(176, 201, 191, 0.18));
+  box-shadow: inset 28px 24px 60px rgba(255, 255, 255, 0.72), 0 30px 80px rgba(31, 44, 39, 0.1);
+  filter: blur(1px);
+  opacity: 0.78;
+  pointer-events: none;
+  transform: rotate(-12deg);
+}
+
+.dashboard-workspace {
+  width: 100%;
+  max-width: 1480px;
+  min-height: calc(100dvh - 126px);
+  margin-inline: auto;
+  padding: clamp(20px, 2.2vw, 34px);
+  border: 1px solid rgba(255, 255, 255, 0.82);
+  border-radius: 30px;
+  background: linear-gradient(145deg, rgba(242, 244, 241, 0.69), rgba(229, 233, 229, 0.5));
+  box-shadow: 0 28px 86px rgba(15, 23, 42, 0.11), inset 0 1px 0 rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(30px) saturate(135%);
+  -webkit-backdrop-filter: blur(30px) saturate(135%);
+}
+
+.dashboard-page-header,
+.dashboard-panel-heading,
+.dashboard-overall-numbers,
+.dashboard-area-title,
+.dashboard-area-title > div,
+.dashboard-text-action,
+.dashboard-panel-heading > button,
+.dashboard-status-chip,
+.dashboard-eyebrow {
+  display: flex;
+  align-items: center;
+}
+
+.dashboard-page-header {
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.dashboard-page-header h1 {
+  margin: 5px 0 4px;
+  color: #111318;
+  font-size: clamp(27px, 2.3vw, 36px);
+  font-weight: 600;
+  line-height: 1.08;
+  letter-spacing: -0.045em;
+}
+
+.dashboard-page-header p {
+  margin: 0;
+  color: #6c7077;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.dashboard-eyebrow {
+  gap: 7px;
+  color: #676b71;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.dashboard-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #00a87d;
+  box-shadow: 0 0 0 5px rgba(0, 168, 125, 0.11);
+}
+
+.dashboard-panel-heading > button,
+.dashboard-text-action,
+.dashboard-ai-action,
+.dashboard-attention-item,
+.dashboard-add-report-card,
+.dashboard-area-item {
+  font: inherit;
+  cursor: pointer;
+}
+
+.dashboard-quiet-action {
+  min-height: 44px;
+  padding: 0 17px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.dashboard-quiet-action {
+  border: 1px solid rgba(255, 255, 255, 0.84);
+  background: rgba(255, 255, 255, 0.56);
+  color: #30343a;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+}
+
+.dashboard-quiet-action:hover {
+  transform: translateY(-1px);
+}
+
+.dashboard-ai-action {
+  min-height: 52px;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+  padding: 7px 11px 7px 8px;
+  border: 1px solid rgba(112, 101, 240, 0.16);
+  border-radius: 17px;
+  color: #313440;
+  background: linear-gradient(135deg, rgba(246, 244, 255, 0.72), rgba(235, 252, 250, 0.56));
+  box-shadow: 0 13px 28px rgba(112, 101, 240, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(14px) saturate(145%);
+  -webkit-backdrop-filter: blur(14px) saturate(145%);
+  transition: transform 170ms ease, border-color 170ms ease, box-shadow 170ms ease;
+}
+
+.dashboard-ai-action-icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  color: #fff;
+  background: linear-gradient(135deg, #7065f0, #38cfc3);
+  box-shadow: 0 8px 17px rgba(112, 101, 240, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.32);
+}
+
+.dashboard-ai-action-copy {
+  min-width: 0;
+  text-align: left;
+}
+
+.dashboard-ai-action-copy small,
+.dashboard-ai-action-copy strong {
+  display: block;
+}
+
+.dashboard-ai-action-copy small {
+  color: #6f66d7;
+  font-size: 8px;
+  font-weight: 850;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.dashboard-ai-action-copy strong {
+  margin-top: 1px;
+  font-size: 11px;
+  font-weight: 780;
+  white-space: nowrap;
+}
+
+.dashboard-ai-action > svg {
+  color: #777c88;
+}
+
+.dashboard-ai-action:hover {
+  border-color: rgba(112, 101, 240, 0.32);
+  box-shadow: 0 16px 34px rgba(112, 101, 240, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.94);
+  transform: translateY(-2px);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: clamp(14px, 1.25vw, 20px);
+}
+
+.dashboard-panel {
+  position: relative;
+  isolation: isolate;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--dashboard-glass-border);
+  border-radius: 21px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.74), rgba(255, 255, 255, 0.46));
+  box-shadow: var(--dashboard-glass-shadow);
+  backdrop-filter: var(--dashboard-glass-blur);
+  -webkit-backdrop-filter: var(--dashboard-glass-blur);
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.dashboard-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.5) 0%, transparent 33%, rgba(255, 255, 255, 0.12) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.82);
+  pointer-events: none;
+}
+
+.dashboard-overall-card {
+  grid-column: span 4;
+  padding: 22px;
+  border-color: rgba(255, 255, 255, 0.16);
+  background: linear-gradient(145deg, rgba(13, 16, 21, 0.94), rgba(29, 33, 39, 0.82));
+  color: #ffffff;
+  box-shadow: 0 24px 50px rgba(17, 19, 24, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(24px) saturate(125%);
+  -webkit-backdrop-filter: blur(24px) saturate(125%);
+}
+
+.dashboard-trend-card {
+  grid-column: span 5;
+  padding: 22px 22px 12px;
+}
+
+.dashboard-progress-card {
+  grid-column: span 3;
+  padding: 22px;
+}
+
+.dashboard-goals-card {
+  grid-column: span 4;
+  padding: 22px;
+}
+
+.dashboard-attention-card {
+  grid-column: span 8;
+  padding: 22px;
+}
+
+.dashboard-areas-card {
+  grid-column: 1 / -1;
+  padding: 22px;
+}
+
+.dashboard-panel-heading {
+  min-height: 36px;
+  justify-content: space-between;
+  gap: 14px;
+  color: #16181d;
+}
+
+.dashboard-panel-heading > div:first-child {
+  min-width: 0;
+}
+
+.dashboard-panel-heading span {
+  display: block;
+  font-size: 14px;
+  font-weight: 750;
+  letter-spacing: -0.018em;
+}
+
+.dashboard-panel-heading small {
+  display: block;
+  margin-top: 3px;
+  color: #8a8e95;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.dashboard-panel-heading--dark {
+  color: #ffffff;
+}
+
+.dashboard-panel-heading--dark small {
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.dashboard-panel-heading > button {
+  flex-shrink: 0;
+  gap: 4px;
+  min-height: 36px;
+  padding: 0 4px;
+  border: 0;
+  background: transparent;
+  color: #767a80;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.dashboard-overall-numbers {
+  gap: 28px;
+  margin: 26px 0 18px;
+}
+
+.dashboard-overall-numbers > div {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.dashboard-overall-numbers strong {
+  font-size: clamp(34px, 3vw, 44px);
+  font-weight: 500;
+  line-height: 0.9;
+  letter-spacing: -0.055em;
+}
+
+.dashboard-overall-numbers span {
+  max-width: 72px;
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.dashboard-overall-track,
+.dashboard-area-track {
+  overflow: hidden;
+  border-radius: 999px;
+}
+
+.dashboard-overall-track {
+  height: 7px;
+  margin-bottom: 18px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.dashboard-overall-track > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #ffffff;
+  transition: width 700ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dashboard-overall-mini-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.dashboard-overall-mini-grid > div {
+  min-width: 0;
+  padding: 13px 9px 11px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.66);
+  background: rgba(247, 248, 246, 0.82);
+  color: #111318;
+  text-align: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.dashboard-overall-mini-grid svg {
+  display: block;
+  margin: 0 auto 8px;
+  color: #555a61;
+}
+
+.dashboard-overall-mini-grid strong,
+.dashboard-overall-mini-grid span {
+  display: block;
+}
+
+.dashboard-overall-mini-grid strong {
+  font-size: 18px;
+  font-weight: 750;
+  line-height: 1;
+}
+
+.dashboard-overall-mini-grid span {
+  margin-top: 4px;
+  overflow: hidden;
+  color: #777b81;
+  font-size: 9px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-status-chip {
+  flex-shrink: 0;
+  gap: 6px;
+  padding: 7px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.86);
+  border-radius: 999px;
+  background: rgba(247, 248, 246, 0.58);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px) saturate(140%);
+  -webkit-backdrop-filter: blur(10px) saturate(140%);
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.dashboard-status-chip > span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+}
+
+.dashboard-chart {
+  width: 100%;
+  height: 225px;
+  margin-top: 4px;
+}
+
+.dashboard-chart-empty {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: #8b9097;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.dashboard-progress-content {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 13px 0 12px;
+}
+
+.dashboard-progress-copy {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  pointer-events: none;
+}
+
+.dashboard-progress-copy strong {
+  color: #111318;
+  font-size: 17px;
+  font-weight: 800;
+}
+
+.dashboard-progress-copy span {
+  color: #858990;
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.dashboard-progress-card .circular-progress > div {
+  display: none;
+}
+
+.dashboard-vibe-legend {
+  display: grid;
+  gap: 7px;
+  min-height: 60px;
+}
+
+.dashboard-vibe-legend > div {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  color: #6f7379;
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.dashboard-vibe-legend > div > span:first-child {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+}
+
+.dashboard-vibe-legend strong {
+  color: #22252a;
+  font-size: 10px;
+}
+
+.dashboard-vibe-legend p {
+  margin: auto;
+  color: #8a8e95;
+  font-size: 11px;
+  text-align: center;
+}
+
+.dashboard-text-action {
+  width: 100%;
+  min-height: 38px;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 13px;
+  border: 1px solid rgba(255, 255, 255, 0.84);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.54);
+  color: #292c31;
+  font-size: 11px;
+  font-weight: 750;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.045), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+}
+
+.dashboard-fraction {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  flex-shrink: 0;
+  border: 1px solid rgba(255, 255, 255, 0.88);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.34);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.86);
+  color: #34373d;
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.dashboard-goals-list {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.dashboard-goals-list > div {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  color: #656970;
+}
+
+.dashboard-goals-list > div > span {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  border: 1px solid #cfd2cd;
+  border-radius: 999px;
+  color: #ffffff;
+}
+
+.dashboard-goals-list p {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.dashboard-goals-list .is-complete {
+  color: #1d2025;
+}
+
+.dashboard-goals-list .is-complete > span {
+  border-color: #111318;
+  background: #111318;
+}
+
+.dashboard-goals-list .is-complete p {
+  text-decoration: line-through;
+  text-decoration-color: #b7bab5;
+}
+
+.dashboard-attention-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 17px;
+}
+
+.dashboard-attention-item,
+.dashboard-add-report-card,
+.dashboard-clear-state {
+  min-height: 116px;
+  border-radius: 16px;
+}
+
+.dashboard-attention-item {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.84);
+  background: rgba(248, 249, 247, 0.56);
+  color: #24272c;
+  text-align: start;
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(12px) saturate(135%);
+  -webkit-backdrop-filter: blur(12px) saturate(135%);
+}
+
+.dashboard-attention-item:hover,
+.dashboard-area-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.09);
+}
+
+.dashboard-attention-icon {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+}
+
+.dashboard-attention-icon--alert {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.dashboard-attention-icon--report {
+  background: #ffedd5;
+  color: #ea580c;
+}
+
+.dashboard-attention-item strong,
+.dashboard-attention-item span,
+.dashboard-attention-item small {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.dashboard-attention-item strong {
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-attention-item span,
+.dashboard-attention-item small {
+  margin-top: 6px;
+  color: #777b82;
+  font-size: 9px;
+  font-weight: 600;
+}
+
+.dashboard-attention-item span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-attention-item > svg {
+  margin-top: 9px;
+  color: #a1a4a9;
+}
+
+.dashboard-clear-state {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid rgba(219, 239, 229, 0.9);
+  background: rgba(238, 249, 243, 0.6);
+  color: #08765a;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.84);
+  backdrop-filter: blur(12px) saturate(135%);
+  -webkit-backdrop-filter: blur(12px) saturate(135%);
+}
+
+.dashboard-clear-state strong,
+.dashboard-clear-state span {
+  display: block;
+}
+
+.dashboard-clear-state strong {
+  font-size: 12px;
+}
+
+.dashboard-clear-state span {
+  margin-top: 3px;
+  color: #5f7b70;
+  font-size: 10px;
+}
+
+.dashboard-add-report-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px;
+  border: 1px dashed rgba(145, 153, 146, 0.66);
+  background: rgba(255, 255, 255, 0.2);
+  color: #6d7178;
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.dashboard-add-report-card svg {
+  width: 34px;
+  height: 34px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.68);
+  color: #111318;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.dashboard-area-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 17px;
+}
+
+.dashboard-area-item {
+  min-height: 132px;
+  padding: 17px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(14, 17, 22, 0.91), rgba(31, 35, 41, 0.78));
+  color: #ffffff;
+  text-align: start;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  box-shadow: 0 18px 36px rgba(17, 19, 24, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(18px) saturate(125%);
+  -webkit-backdrop-filter: blur(18px) saturate(125%);
+}
+
+.dashboard-area-title {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dashboard-area-title > div {
+  min-width: 0;
+  gap: 7px;
+}
+
+.dashboard-area-title strong {
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 750;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-area-title > span {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.dashboard-area-item p {
+  margin: 19px 0 8px;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.dashboard-area-track {
+  height: 5px;
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.dashboard-area-track > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #ffffff;
+}
+
+.dashboard-area-item small {
+  display: block;
+  margin-top: 9px;
+  color: rgba(255, 255, 255, 0.44);
+  font-size: 9px;
+  font-weight: 600;
+}
+
+.dashboard-area-item--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border-style: dashed;
+  background: linear-gradient(145deg, rgba(30, 33, 39, 0.86), rgba(20, 23, 28, 0.75));
+  text-align: center;
+}
+
+@media (hover: hover) {
+  .dashboard-panel:hover {
+    border-color: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 24px 62px rgba(15, 23, 42, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.94);
+    transform: translateY(-2px);
+  }
+
+  .dashboard-overall-card:hover,
+  .dashboard-area-item:hover {
+    border-color: rgba(255, 255, 255, 0.24);
+    box-shadow: 0 26px 56px rgba(17, 19, 24, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+  }
+}
+
+.dashboard-area-item--empty span {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 10px;
+}
+
+@media (max-width: 1279px) and (min-width: 1024px) {
+  .dashboard-overall-card { grid-column: span 5; }
+  .dashboard-trend-card { grid-column: span 7; }
+  .dashboard-progress-card { grid-column: span 4; }
+  .dashboard-goals-card { grid-column: span 8; }
+  .dashboard-attention-card { grid-column: 1 / -1; }
+}
+
+@media (max-width: 1023px) {
+  .dashboard-view {
+    padding: 58px 0 0;
+  }
+
+  .dashboard-view::before {
+    inset: 22px -24px -24px;
+    opacity: 0.68;
+    filter: blur(3px) saturate(110%);
+  }
+
+  .dashboard-view::after {
+    top: 104px;
+    right: -96px;
+    width: 280px;
+    opacity: 0.58;
+  }
+
+  .dashboard-workspace {
+    min-height: 100%;
+    padding: 18px;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .dashboard-panel {
+    backdrop-filter: blur(18px) saturate(138%);
+    -webkit-backdrop-filter: blur(18px) saturate(138%);
+  }
+
+  .dashboard-overall-card { grid-column: span 5; }
+  .dashboard-trend-card { grid-column: span 7; }
+  .dashboard-progress-card { grid-column: span 5; }
+  .dashboard-goals-card { grid-column: span 7; }
+  .dashboard-attention-card { grid-column: 1 / -1; }
+}
+
+@media (max-width: 767px) {
+  .dashboard-workspace {
+    padding: 14px 0 8px;
+  }
+
+  .dashboard-page-header {
+    align-items: flex-end;
+    margin-bottom: 16px;
+    padding-inline: 2px;
+  }
+
+  .dashboard-page-header h1 {
+    font-size: clamp(25px, 7vw, 30px);
+  }
+
+  .dashboard-page-header p {
+    max-width: 240px;
+    font-size: 11px;
+  }
+
+  .dashboard-ai-action {
+    min-height: 46px;
+    grid-template-columns: 32px auto;
+    padding: 6px 9px 6px 7px;
+    border-radius: 15px;
+  }
+
+  .dashboard-ai-action-icon {
+    width: 32px;
+    height: 32px;
+  }
+
+  .dashboard-ai-action-copy strong {
+    font-size: 10px;
+  }
+
+  .dashboard-ai-action > svg {
+    display: none;
+  }
+
+  .dashboard-quiet-action {
+    display: none;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+    gap: 13px;
+  }
+
+  .dashboard-overall-card,
+  .dashboard-trend-card,
+  .dashboard-progress-card,
+  .dashboard-goals-card,
+  .dashboard-attention-card,
+  .dashboard-areas-card {
+    grid-column: 1;
+  }
+
+  .dashboard-panel,
+  .dashboard-overall-card,
+  .dashboard-trend-card,
+  .dashboard-progress-card,
+  .dashboard-goals-card,
+  .dashboard-attention-card,
+  .dashboard-areas-card {
+    padding: 18px;
+    border-radius: 19px;
+  }
+
+  .dashboard-overall-numbers {
+    justify-content: space-between;
+  }
+
+  .dashboard-chart {
+    height: 210px;
+  }
+
+  .dashboard-progress-content {
+    width: 46%;
+    min-width: 140px;
+    float: left;
+    margin-inline-end: 12px;
+  }
+
+  .dashboard-progress-card::after {
+    content: '';
+    display: block;
+    clear: both;
+  }
+
+  .dashboard-vibe-legend {
+    padding-top: 28px;
+  }
+
+  .dashboard-text-action {
+    width: calc(54% - 12px);
+  }
+
+  .dashboard-attention-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-attention-item,
+  .dashboard-add-report-card,
+  .dashboard-clear-state {
+    min-height: 96px;
+  }
+
+  .dashboard-add-report-card {
+    flex-direction: row;
+  }
+
+  .dashboard-area-grid {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(258px, 84%);
+    grid-template-columns: none;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: inline mandatory;
+    scrollbar-width: none;
+  }
+
+  .dashboard-area-grid::-webkit-scrollbar {
+    display: none;
+  }
+
+  .dashboard-area-item {
+    scroll-snap-align: start;
+  }
+}
+
+@media (max-width: 390px) {
+  .dashboard-page-header p,
+  .dashboard-eyebrow {
+    display: none;
+  }
+
+  .dashboard-overall-numbers {
+    gap: 16px;
+  }
+
+  .dashboard-overall-mini-grid > div {
+    padding-inline: 5px;
+  }
+
+  .dashboard-panel-heading small {
+    max-width: 190px;
+  }
+
+  .dashboard-ai-action-copy small {
+    display: none;
+  }
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .dashboard-workspace {
+    background: rgba(239, 241, 238, 0.97);
+  }
+
+  .dashboard-panel {
+    background: rgba(255, 255, 255, 0.96);
+  }
+
+  .dashboard-overall-card,
+  .dashboard-area-item {
+    background: #171a1f;
+  }
+}
+
+[dir='rtl'] .dashboard-attention-item,
+[dir='rtl'] .dashboard-area-item {
+  text-align: right;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-view *,
+  .dashboard-view *::before,
+  .dashboard-view *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -1,0 +1,449 @@
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Activity,
+  ArrowUpRight,
+  Check,
+  ChevronRight,
+  CircleAlert,
+  Clock3,
+  Compass,
+  MapPin,
+  Plus,
+  Radio,
+  ShieldCheck,
+  Sparkles,
+  Target,
+  Users,
+} from 'lucide-react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { useAuth } from '../contexts/AuthContext';
+import { getSafetyLevel } from '../lib/safetyAnalytics';
+import {
+  buildAreaSummaries,
+  buildAttentionItems,
+  buildDashboardMetrics,
+  buildVibeDistribution,
+  buildWeeklyTrend,
+} from '../lib/dashboardAnalytics';
+import type { SOS, Vibe } from '../types';
+
+import { CircularProgress } from './shared';
+import './DashboardView.css';
+
+const VoiceChatModal = React.lazy(() => import('./VoiceChatModal'));
+
+/* eslint-disable no-unused-vars -- the legacy base rule misreads TypeScript callback signatures */
+interface DashboardViewProps {
+  vibes: Vibe[];
+  sosAlerts: SOS[];
+  userLocation: [number, number] | null;
+  onNewReport: () => void;
+  onNavigate: (tab: 'map' | 'reports') => void;
+  onNavigateToMap: (latitude: number, longitude: number) => void;
+}
+/* eslint-enable no-unused-vars */
+
+const VIBE_COLORS: Record<string, string> = {
+  safe: '#10b981',
+  calm: '#3b82f6',
+  quiet: '#06b6d4',
+  lively: '#f59e0b',
+  festive: '#8b5cf6',
+  crowded: '#ef4444',
+  suspicious: '#f97316',
+  dangerous: '#dc2626',
+  noisy: '#eab308',
+  streetlight: '#6366f1',
+  sidewalk: '#64748b',
+  construction: '#f59e0b',
+  pothole: '#b45309',
+  traffic: '#ef4444',
+  other: '#6b7280',
+};
+
+function formatRelativeTime(value: string, locale: string): string {
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) {
+    return '';
+  }
+
+  const diffMinutes = Math.round((timestamp - Date.now()) / 60_000);
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+
+  if (Math.abs(diffMinutes) < 60) {
+    return formatter.format(diffMinutes, 'minute');
+  }
+  const diffHours = Math.round(diffMinutes / 60);
+  if (Math.abs(diffHours) < 24) {
+    return formatter.format(diffHours, 'hour');
+  }
+  return formatter.format(Math.round(diffHours / 24), 'day');
+}
+
+function getGreetingKey(date: Date): 'morning' | 'afternoon' | 'evening' {
+  const hour = date.getHours();
+  if (hour < 12) {
+    return 'morning';
+  }
+  if (hour < 18) {
+    return 'afternoon';
+  }
+  return 'evening';
+}
+
+const DashboardView: React.FC<DashboardViewProps> = ({
+  vibes,
+  sosAlerts,
+  userLocation,
+  onNewReport,
+  onNavigate,
+  onNavigateToMap,
+}) => {
+  const { t, i18n } = useTranslation();
+  const { user } = useAuth();
+  const [isAssistantOpen, setIsAssistantOpen] = useState(false);
+  const now = useMemo(() => new Date(), []);
+  const locale = i18n.language || 'en-CA';
+  const allReports = useMemo(() => [...vibes, ...sosAlerts], [vibes, sosAlerts]);
+  const metrics = useMemo(
+    () => buildDashboardMetrics(vibes, sosAlerts, user?.id, now),
+    [vibes, sosAlerts, user?.id, now],
+  );
+  const weeklyTrend = useMemo(
+    () => buildWeeklyTrend(allReports, now, locale),
+    [allReports, now, locale],
+  );
+  const distribution = useMemo(
+    () => buildVibeDistribution(vibes, now),
+    [vibes, now],
+  );
+  const attentionItems = useMemo(
+    () => buildAttentionItems(vibes, sosAlerts, now),
+    [vibes, sosAlerts, now],
+  );
+  const areas = useMemo(
+    () => buildAreaSummaries(allReports, now),
+    [allReports, now],
+  );
+
+  const safetyLevel = metrics.safetyScore === null
+    ? { description: String(t('dashboard.noData')), color: '#94a3b8' }
+    : getSafetyLevel(metrics.safetyScore);
+  const displayName = user?.first_name || user?.username || String(t('dashboard.neighbour'));
+  const greetingKey = getGreetingKey(now);
+  const hasTrendData = weeklyTrend.some((point) => point.reports > 0);
+
+  const goals = [
+    { label: String(t('dashboard.goals.firstPulse')), complete: metrics.monthlyUserReports >= 1 },
+    { label: String(t('dashboard.goals.stayActive')), complete: metrics.monthlyUserReports >= 2 },
+    { label: String(t('dashboard.goals.communityVoice')), complete: metrics.monthlyUserReports >= 4 },
+    { label: String(t('dashboard.goals.trustedProfile')), complete: user?.verification_level !== 'basic' && Boolean(user?.verification_level) },
+  ];
+
+  return (
+    <section className="dashboard-view" aria-labelledby="dashboard-title">
+      <div className="dashboard-workspace">
+        <header className="dashboard-page-header">
+          <div>
+            <div className="dashboard-eyebrow">
+              <span className="dashboard-live-dot" />
+              {t('dashboard.liveOverview')}
+            </div>
+            <h1 id="dashboard-title">
+              {t(`dashboard.greetings.${greetingKey}`)}, {displayName}!
+            </h1>
+            <p>
+              {userLocation
+                ? t('dashboard.locationReady')
+                : t('dashboard.locationUnavailable')}
+            </p>
+          </div>
+          <button className="dashboard-ai-action" type="button" onClick={() => setIsAssistantOpen(true)}>
+            <span className="dashboard-ai-action-icon" aria-hidden="true"><Sparkles size={17} /></span>
+            <span className="dashboard-ai-action-copy">
+              <small>Hyper AI</small>
+              <strong>Ask assistant</strong>
+            </span>
+            <ArrowUpRight size={16} aria-hidden="true" />
+          </button>
+        </header>
+
+        <div className="dashboard-grid">
+          <article className="dashboard-panel dashboard-overall-card">
+            <div className="dashboard-panel-heading dashboard-panel-heading--dark">
+              <div>
+                <span>{t('dashboard.overall.title')}</span>
+                <small>{t('dashboard.overall.period')}</small>
+              </div>
+              <Sparkles size={18} aria-hidden="true" />
+            </div>
+
+            <div className="dashboard-overall-numbers">
+              <div>
+                <strong>{metrics.reportsToday}</strong>
+                <span>{t('dashboard.metrics.reportsToday')}</span>
+              </div>
+              <div>
+                <strong>{metrics.activeAlerts}</strong>
+                <span>{t('dashboard.metrics.activeAlerts')}</span>
+              </div>
+            </div>
+
+            <div className="dashboard-overall-track" aria-hidden="true">
+              <span style={{ width: `${metrics.safetyScore ?? 0}%` }} />
+            </div>
+
+            <div className="dashboard-overall-mini-grid">
+              <div>
+                <ShieldCheck size={17} />
+                <strong>{metrics.safetyScore === null ? '—' : `${metrics.safetyScore}%`}</strong>
+                <span>{t('dashboard.metrics.safety')}</span>
+              </div>
+              <div>
+                <Users size={17} />
+                <strong>{metrics.contributors}</strong>
+                <span>{t('dashboard.metrics.contributors')}</span>
+              </div>
+              <div>
+                <Radio size={17} />
+                <strong>{metrics.weeklyReports}</strong>
+                <span>{t('dashboard.metrics.weeklyReports')}</span>
+              </div>
+            </div>
+          </article>
+
+          <article className="dashboard-panel dashboard-trend-card">
+            <div className="dashboard-panel-heading">
+              <div>
+                <span>{t('dashboard.trend.title')}</span>
+                <small>{t('dashboard.trend.subtitle')}</small>
+              </div>
+              <div className="dashboard-status-chip" style={{ color: safetyLevel.color }}>
+                <span style={{ background: safetyLevel.color }} />
+                {safetyLevel.description}
+              </div>
+            </div>
+
+            <div className="dashboard-chart" aria-label={String(t('dashboard.trend.chartLabel'))}>
+              {hasTrendData ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={weeklyTrend} margin={{ top: 14, right: 8, left: -24, bottom: 0 }}>
+                    <defs>
+                      <linearGradient id="dashboardSafetyFill" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#111318" stopOpacity={0.18} />
+                        <stop offset="95%" stopColor="#111318" stopOpacity={0.01} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid vertical={false} stroke="rgba(92, 99, 95, 0.14)" strokeDasharray="2 5" />
+                    <XAxis dataKey="label" axisLine={false} tickLine={false} tick={{ fill: '#71717a', fontSize: 11, fontWeight: 600 }} />
+                    <YAxis domain={[0, 100]} axisLine={false} tickLine={false} tick={{ fill: '#a1a1aa', fontSize: 10 }} tickFormatter={(value) => `${value}%`} />
+                    <Tooltip
+                      cursor={{ stroke: 'rgba(55, 65, 61, 0.35)', strokeDasharray: '3 3' }}
+                      contentStyle={{
+                        borderRadius: '14px',
+                        border: '1px solid rgba(255, 255, 255, 0.88)',
+                        backgroundColor: 'rgba(255, 255, 255, 0.78)',
+                        boxShadow: '0 16px 36px rgba(15, 23, 42, 0.12)',
+                        backdropFilter: 'blur(16px) saturate(145%)',
+                        fontSize: '12px',
+                      }}
+                      formatter={(value) => [`${value ?? 0}%`, String(t('dashboard.metrics.safety'))]}
+                      labelFormatter={(label) => `${label}`}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="score"
+                      stroke="#111318"
+                      strokeWidth={2.25}
+                      fill="url(#dashboardSafetyFill)"
+                      connectNulls
+                      dot={{ r: 3, fill: '#ffffff', stroke: '#111318', strokeWidth: 2 }}
+                      activeDot={{ r: 5, fill: '#111318', stroke: '#ffffff', strokeWidth: 2 }}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="dashboard-chart-empty">
+                  <Activity size={24} />
+                  <span>{t('dashboard.trend.empty')}</span>
+                </div>
+              )}
+            </div>
+          </article>
+
+          <article className="dashboard-panel dashboard-progress-card">
+            <div className="dashboard-panel-heading">
+              <div>
+                <span>{t('dashboard.progress.title')}</span>
+                <small>{t('dashboard.progress.subtitle')}</small>
+              </div>
+              <Target size={18} aria-hidden="true" />
+            </div>
+
+            <div className="dashboard-progress-content">
+              <CircularProgress
+                percentage={metrics.monthlyGoalProgress}
+                size={122}
+                strokeWidth={10}
+                color="#111318"
+                backgroundColor="rgba(17, 19, 24, 0.1)"
+              />
+              <div className="dashboard-progress-copy">
+                <strong>{metrics.monthlyUserReports}/{metrics.monthlyGoal}</strong>
+                <span>{t('dashboard.progress.reports')}</span>
+              </div>
+            </div>
+
+            <div className="dashboard-vibe-legend">
+              {distribution.length > 0 ? distribution.slice(0, 3).map((item) => (
+                <div key={item.type}>
+                  <span style={{ background: VIBE_COLORS[item.type] ?? '#6b7280' }} />
+                  <span>{t(`vibes.${item.type}`, item.type)}</span>
+                  <strong>{item.percentage}%</strong>
+                </div>
+              )) : (
+                <p>{t('dashboard.progress.empty')}</p>
+              )}
+            </div>
+
+            <button className="dashboard-text-action" type="button" onClick={() => onNavigate('reports')}>
+              {t('dashboard.viewCommunity')}
+              <ArrowUpRight size={15} />
+            </button>
+          </article>
+
+          <article className="dashboard-panel dashboard-goals-card">
+            <div className="dashboard-panel-heading">
+              <div>
+                <span>{t('dashboard.goals.title')}</span>
+                <small>{goals.filter((goal) => goal.complete).length}/{goals.length} {t('dashboard.goals.complete')}</small>
+              </div>
+              <div className="dashboard-fraction">{goals.filter((goal) => goal.complete).length}/{goals.length}</div>
+            </div>
+            <div className="dashboard-goals-list">
+              {goals.map((goal) => (
+                <div key={goal.label} className={goal.complete ? 'is-complete' : ''}>
+                  <span>{goal.complete && <Check size={12} />}</span>
+                  <p>{goal.label}</p>
+                </div>
+              ))}
+            </div>
+          </article>
+
+          <article className="dashboard-panel dashboard-attention-card">
+            <div className="dashboard-panel-heading">
+              <div>
+                <span>{t('dashboard.attention.title')} ({attentionItems.length})</span>
+                <small>{t('dashboard.attention.subtitle')}</small>
+              </div>
+              <button type="button" onClick={() => onNavigate('reports')}>
+                {t('dashboard.viewAll')}
+                <ChevronRight size={15} />
+              </button>
+            </div>
+
+            <div className="dashboard-attention-grid">
+              {attentionItems.map((item) => (
+                <button
+                  key={`${item.type}-${item.id}`}
+                  className="dashboard-attention-item"
+                  type="button"
+                  onClick={() => onNavigateToMap(item.latitude, item.longitude)}
+                >
+                  <div className={`dashboard-attention-icon dashboard-attention-icon--${item.type}`}>
+                    {item.type === 'alert' ? <CircleAlert size={18} /> : <Activity size={18} />}
+                  </div>
+                  <div>
+                    <strong>{item.type === 'alert' ? t('dashboard.attention.emergency') : t(`vibes.${item.vibeType}`, item.vibeType)}</strong>
+                    <span><MapPin size={12} /> {item.location}</span>
+                    <small><Clock3 size={12} /> {formatRelativeTime(item.createdAt, locale)}</small>
+                  </div>
+                  <ChevronRight size={17} />
+                </button>
+              ))}
+
+              {attentionItems.length === 0 && (
+                <div className="dashboard-clear-state">
+                  <ShieldCheck size={24} />
+                  <div>
+                    <strong>{t('dashboard.attention.clearTitle')}</strong>
+                    <span>{t('dashboard.attention.clearSubtitle')}</span>
+                  </div>
+                </div>
+              )}
+
+              <button className="dashboard-add-report-card" type="button" onClick={onNewReport}>
+                <Plus size={18} />
+                <span>{t('dashboard.attention.add')}</span>
+              </button>
+            </div>
+          </article>
+
+          <article className="dashboard-panel dashboard-areas-card">
+            <div className="dashboard-panel-heading">
+              <div>
+                <span>{t('dashboard.areas.title')}</span>
+                <small>{t('dashboard.areas.subtitle')}</small>
+              </div>
+              <button type="button" onClick={() => onNavigate('map')}>
+                {t('dashboard.openMap')}
+                <Compass size={15} />
+              </button>
+            </div>
+
+            <div className="dashboard-area-grid">
+              {areas.map((area) => (
+                <button
+                  key={area.key}
+                  className="dashboard-area-item"
+                  type="button"
+                  onClick={() => onNavigateToMap(area.latitude, area.longitude)}
+                >
+                  <div className="dashboard-area-title">
+                    <div>
+                      <MapPin size={15} />
+                      <strong>{area.label}</strong>
+                    </div>
+                    <span>{area.safetyScore}%</span>
+                  </div>
+                  <p>{area.reports} {t('dashboard.areas.reports')}</p>
+                  <div className="dashboard-area-track"><span style={{ width: `${area.safetyScore}%` }} /></div>
+                  <small>{t('dashboard.areas.updated')} {formatRelativeTime(area.lastUpdated, locale)}</small>
+                </button>
+              ))}
+
+              {areas.length === 0 && (
+                <button className="dashboard-area-item dashboard-area-item--empty" type="button" onClick={onNewReport}>
+                  <Plus size={20} />
+                  <strong>{t('dashboard.areas.emptyTitle')}</strong>
+                  <span>{t('dashboard.areas.emptySubtitle')}</span>
+                </button>
+              )}
+            </div>
+          </article>
+        </div>
+      </div>
+      {isAssistantOpen && (
+        <React.Suspense fallback={null}>
+          <VoiceChatModal
+            isOpen
+            onClose={() => setIsAssistantOpen(false)}
+            userLocation={userLocation}
+          />
+        </React.Suspense>
+      )}
+    </section>
+  );
+};
+
+export default DashboardView;

--- a/src/components/EditProfileModal.tsx
+++ b/src/components/EditProfileModal.tsx
@@ -2,124 +2,13 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, VStack, HStack, Text, Button, Input } from '@chakra-ui/react';
 import { Geolocation } from '@capacitor/geolocation';
-import { User, MapPin, Phone, FileText, Camera, X } from 'lucide-react';
+import { User, Camera, X } from 'lucide-react';
 
 import { useAuth } from '../contexts/AuthContext';
 import { uploadService } from '../services/upload';
 import { userLocationService } from '../services/userLocationService';
 import { reverseGeocode } from '../lib/geocoding';
 import { INTEREST_CATEGORIES } from '../types';
-
-// Arabic translations for interests
-const INTEREST_TRANSLATIONS: { [key: string]: string } = {
-  // Sports & Fitness
-  'Running': 'الجري',
-  'Gym': 'النادي الرياضي',
-  'Yoga': 'اليوغا',
-  'Football': 'كرة القدم',
-  'Basketball': 'كرة السلة',
-  'Swimming': 'السباحة',
-  'Cycling': 'ركوب الدراجة',
-  'Tennis': 'التنس',
-  'Martial Arts': 'الفنون القتالية',
-  'Dance': 'الرقص',
-  // Music & Arts
-  'Concerts': 'الحفلات الموسيقية',
-  'Theater': 'المسرح',
-  'Painting': 'الرسم',
-  'Photography': 'التصوير',
-  'Music Production': 'إنتاج الموسيقى',
-  'Film': 'الأفلام',
-  'Writing': 'الكتابة',
-  'Sculpture': 'النحت',
-  'Design': 'التصميم',
-  'Crafts': 'الحرف اليدوية',
-  // Food & Dining
-  'Restaurants': 'المطاعم',
-  'Cooking': 'الطبخ',
-  'Baking': 'الخبز',
-  'Coffee Shops': 'مقاهي القهوة',
-  'Fine Dining': 'الطعام الفاخر',
-  'Street Food': 'طعام الشارع',
-  'Vegan': 'النباتي',
-  'Wine': 'النبيذ',
-  'Beer': 'البيرة',
-  'Cocktails': 'الكوكتيلات',
-  // Education & Learning
-  'Courses': 'الدورات',
-  'Workshops': 'ورش العمل',
-  'Books': 'الكتب',
-  'Online Learning': 'التعلم عبر الإنترنت',
-  'Languages': 'اللغات',
-  'Science': 'العلم',
-  'History': 'التاريخ',
-  'Technology': 'التكنولوجيا',
-  'Business': 'الأعمال',
-  'Art History': 'تاريخ الفن',
-  // Environment & Nature
-  'Hiking': 'التنزه',
-  'Camping': 'التخييم',
-  'Gardening': 'البستنة',
-  'Sustainability': 'الاستدامة',
-  'Wildlife': 'الحياة البرية',
-  'Conservation': 'الحفاظ على البيئة',
-  'Fishing': 'الصيد',
-  'Bird Watching': 'مراقبة الطيور',
-  'Eco-friendly Living': 'الحياة الصديقة للبيئة',
-  // Gaming & Tech
-  'Video Games': 'ألعاب الفيديو',
-  'Programming': 'البرمجة',
-  'Gadgets': 'الأدوات التقنية',
-  'AI/ML': 'الذكاء الاصطناعي/التعلم الآلي',
-  'Cybersecurity': 'الأمن السيبراني',
-  'Mobile Apps': 'تطبيقات الهاتف',
-  'Web Development': 'تطوير الويب',
-  'Hardware': 'الأجهزة',
-  'Virtual Reality': 'الواقع الافتراضي',
-  'Board Games': 'ألعاب الطاولة',
-  // Social & Community
-  'Meetups': 'اللقاءات',
-  'Volunteering': 'التطوع',
-  'Clubs': 'النوادي',
-  'Networking': 'التواصل',
-  'Charity': 'الجمعيات الخيرية',
-  'Community Events': 'فعاليات المجتمع',
-  'Book Clubs': 'نوادي الكتب',
-  'Sports Teams': 'الفرق الرياضية',
-  'Cultural Events': 'الفعاليات الثقافية',
-  'Religious Groups': 'المجموعات الدينية',
-  // Shopping & Lifestyle
-  'Markets': 'الأسواق',
-  'Fashion': 'الأزياء',
-  'Beauty': 'الجمال',
-  'Home Decor': 'ديكور المنزل',
-  'Antiques': 'القطع الأثرية',
-  'Vintage': 'العتيق',
-  'Luxury': 'الفاخر',
-  'Thrifting': 'التسوق الرخيص',
-  'Art Galleries': 'معارض الفن',
-  'Craft Markets': 'أسواق الحرف اليدوية',
-  // Transportation
-  'Public Transport': 'النقل العام',
-  'Electric Vehicles': 'المركبات الكهربائية',
-  'Motorcycles': 'الدراجات النارية',
-  'Car Sharing': 'مشاركة السيارات',
-  'Ride Sharing': 'مشاركة الركوب',
-  'Walking': 'المشي',
-  'Scooters': 'السكوترات',
-  'Boats': 'القوارب',
-  'Aviation': 'الطيران',
-  // Home & Garden
-  'DIY': 'الصنع بنفسك',
-  'Home Improvement': 'تحسين المنزل',
-  'Interior Design': 'تصميم الديكور الداخلي',
-  'Landscaping': 'تصميم الحدائق',
-  'Furniture': 'الأثاث',
-  'Tools': 'الأدوات',
-  'Renovation': 'التجديد',
-  'Smart Home': 'المنزل الذكي',
-  'Pets': 'الحيوانات الأليفة',
-};
 
 interface EditProfileModalProps {
   isOpen: boolean;
@@ -142,12 +31,15 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
   const [profilePicture, setProfilePicture] = useState<File | null>(null);
   const [profilePicturePreview, setProfilePicturePreview] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [locationLoading, setLocationLoading] = useState(false);
+  const [saveError, setSaveError] = useState('');
   const [detectedCoordinates, setDetectedCoordinates] = useState<[number, number] | null>(null);
 
   // Load current user data when modal opens
   useEffect(() => {
     if (isOpen && user) {
+      setSaveError('');
+      setProfilePicture(null);
+      setDetectedCoordinates(null);
       setFormData({
         firstName: user.first_name || '',
         lastName: user.last_name || '',
@@ -169,8 +61,6 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
       console.log('Geolocation not supported');
       return;
     }
-
-    setLocationLoading(true);
 
     try {
       console.log('Requesting location permission and detection...');
@@ -204,8 +94,6 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
     } catch (error: any) {
       console.error('Location detection failed:', error);
       // Don't show error to user, just leave location field as is
-    } finally {
-      setLocationLoading(false);
     }
   };
 
@@ -240,6 +128,17 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
   };
 
   const handleSave = async () => {
+    if (!user) {
+      setSaveError('You need to be signed in to save profile changes.');
+      return;
+    }
+
+    if (!formData.email.trim()) {
+      setSaveError('Email address is required.');
+      return;
+    }
+
+    setSaveError('');
     setIsLoading(true);
     try {
       let profilePictureUrl = user?.profile_picture_url || '';
@@ -252,11 +151,11 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
 
       // Update profile
       await updateProfile({
-        first_name: formData.firstName,
-        last_name: formData.lastName,
-        email: formData.email,
-        phone: formData.phone,
-        location: formData.location,
+        first_name: formData.firstName.trim(),
+        last_name: formData.lastName.trim(),
+        email: formData.email.trim(),
+        phone: formData.phone.trim(),
+        location: formData.location.trim(),
         interests: formData.interests,
         profile_picture_url: profilePictureUrl,
       });
@@ -279,6 +178,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
       onClose();
     } catch (error) {
       console.error('Error updating profile:', error);
+      setSaveError(error instanceof Error ? error.message : 'Profile changes could not be saved.');
     } finally {
       setIsLoading(false);
     }
@@ -552,7 +452,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
                             borderColor: formData.interests.includes(item) ? 'blue.600' : 'gray.300',
                           }}
                         >
-                          {INTEREST_TRANSLATIONS[item] || item}
+                          {item}
                         </Button>
                       ))}
                     </HStack>
@@ -570,6 +470,20 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ isOpen, onClose }) 
           borderColor="gray.200"
           bg="gray.50"
         >
+          {saveError && (
+            <Text
+              role="alert"
+              mb={3}
+              px={3}
+              py={2}
+              borderRadius="10px"
+              bg="red.50"
+              color="red.700"
+              fontSize="13px"
+            >
+              {saveError}
+            </Text>
+          )}
           <HStack gap={3}>
             <Button
               flex={1}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,109 +1,28 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '../contexts/AuthContext';
-import { useVibe } from '../contexts/VibeContext';
+
 import { useBreakpoint } from '../lib/useBreakpoint';
-import { VIBE_CONFIG } from '../constants/vibes';
+
 import NotificationBell from './shared/NotificationBell';
 
-interface HeaderProps {
-  onNavigateToProfile?: () => void;
-}
-
-const Header: React.FC<HeaderProps> = ({ onNavigateToProfile }) => {
+const Header: React.FC = () => {
   const { t } = useTranslation();
-  const { user } = useAuth();
-  const { currentLocationVibe } = useVibe();
-  const { isDesktop, isMobile } = useBreakpoint();
+  const { isMobile } = useBreakpoint();
 
-  const getUserInitials = () => {
-    if (user?.first_name && user?.last_name) {
-      return `${user.first_name.charAt(0)}${user.last_name.charAt(0)}`.toUpperCase();
-    }
-    if (user?.first_name) {
-      return user.first_name.charAt(0).toUpperCase();
-    }
-    if (user?.username) {
-      return user.username.charAt(0).toUpperCase();
-    }
-    return 'U';
-  };
+  if (!isMobile) {
+    return null;
+  }
 
   return (
-    <header
-      style={isMobile ? {
-        position: 'fixed', top: 0, left: 0, right: 0,
-        height: '56px', zIndex: 100,
-        background: 'rgba(9,9,11,0.93)',
-        borderBottom: '0.5px solid rgba(255,255,255,0.07)',
-        backdropFilter: 'blur(20px)',
-        WebkitBackdropFilter: 'blur(20px)',
-        display: 'flex', alignItems: 'center',
-        padding: '0 16px', gap: '12px',
-      } : {
-        height: '64px',
-        background: 'rgba(9,9,11,0.92)',
-        borderBottom: '0.5px solid var(--wire)',
-        backdropFilter: 'blur(20px)',
-        WebkitBackdropFilter: 'blur(20px)',
-        display: 'flex', alignItems: 'center',
-        padding: '0 28px', gap: '16px',
-        position: 'sticky', top: 0, zIndex: 70,
-      }}
-    >
-      {/* Mobile: Logo mark + wordmark */}
-      {isMobile && (
-        <div style={{ display:'flex', alignItems:'center', gap:'8px', flexShrink:0 }}>
-          <div style={{
-            width:'28px', height:'28px', borderRadius:'8px',
-            background:'linear-gradient(135deg,#00c896,#4f8ef7)',
-            display:'flex', alignItems:'center', justifyContent:'center',
-          }}>
-            <div style={{ width:'11px', height:'11px', background:'rgba(9,9,11,0.5)', clipPath:'polygon(50% 0%,100% 25%,100% 75%,50% 100%,0% 75%,0% 25%)' }} />
-          </div>
-          <span style={{ fontSize:'15px', fontWeight:'800', color:'var(--t1)', letterSpacing:'-0.3px' }}>HyperApp</span>
-        </div>
-      )}
-
-      {/* Center: Vibe pill */}
-      <div style={{ flex:1, display:'flex', justifyContent:'center' }}>
-        {currentLocationVibe ? (
-          <div style={{
-            display:'flex', alignItems:'center', gap:'7px',
-            background:'rgba(255,255,255,0.05)', border:'0.5px solid rgba(255,255,255,0.09)',
-            borderRadius:'20px', padding:'5px 12px 5px 8px',
-          }}>
-            <div style={{
-              width:'8px', height:'8px', borderRadius:'50%', flexShrink:0,
-              background: (VIBE_CONFIG[currentLocationVibe.type as keyof typeof VIBE_CONFIG]?.color) || 'var(--accent)',
-            }} />
-            <span style={{ fontSize:'12px', fontWeight:'600', color:'var(--t1)' }}>
-              {VIBE_CONFIG[currentLocationVibe.type as keyof typeof VIBE_CONFIG]?.label || currentLocationVibe.type}
-            </span>
-            <span style={{ fontSize:'12px', fontWeight:'700', color: VIBE_CONFIG[currentLocationVibe.type as keyof typeof VIBE_CONFIG]?.color || 'var(--accent)' }}>
-              {Math.round(currentLocationVibe.percentage)}%
-            </span>
-          </div>
-        ) : (
-          <span style={{ fontSize:'12px', color:'var(--t3)' }}>Scanning area…</span>
-        )}
-      </div>
-
-      {/* Right: Bell + Avatar */}
-      <div style={{ display:'flex', alignItems:'center', gap:'10px', flexShrink:0 }}>
-        <NotificationBell />
-        <div
-          onClick={onNavigateToProfile}
-          style={{
-            width:'32px', height:'32px', borderRadius:'9px', flexShrink:0,
-            background:'linear-gradient(135deg,#00c896,#4f8ef7)',
-            display:'flex', alignItems:'center', justifyContent:'center',
-            cursor:'pointer', fontSize:'12px', fontWeight:'700', color:'white',
-          }}
-        >
-          {getUserInitials()}
+    <header className="app-mobile-header">
+      <div className="app-mobile-header__brand">
+        <span className="app-mobile-header__mark" aria-hidden="true"><span /></span>
+        <div>
+          <strong>HyperApp</strong>
+          <small>{t('app.communitySafety', 'Community safety')}</small>
         </div>
       </div>
+      <NotificationBell />
     </header>
   );
 };

--- a/src/components/HubView.tsx
+++ b/src/components/HubView.tsx
@@ -37,7 +37,7 @@ import { hubService } from '../services/hub';
 import { reverseGeocode } from '../lib/geocoding';
 import { backgroundLocationService } from '../services/backgroundLocationService';
 import { supabase } from '../lib/supabase';
-import { formatNumber, formatPercentage, formatDistance, formatTemperature } from '../lib/arabicUtils';
+import { formatNumber, formatPercentage, formatDistance, formatTemperature } from '../lib/displayFormatters';
 
 interface HubViewProps {
   userLocation: [number, number] | null;

--- a/src/components/LocationOverrideModal.tsx
+++ b/src/components/LocationOverrideModal.tsx
@@ -40,6 +40,7 @@ const LocationOverrideModal: React.FC<LocationOverrideModalProps> = ({
 
   // Focus management and body scroll prevention
   useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
     if (isOpen) {
       // Prevent body scroll
       document.body.style.overflow = 'hidden';
@@ -48,12 +49,10 @@ const LocationOverrideModal: React.FC<LocationOverrideModalProps> = ({
       setTimeout(() => {
         firstLocationButtonRef.current?.focus();
       }, 100);
-    } else {
-      document.body.style.overflow = 'unset';
     }
 
     return () => {
-      document.body.style.overflow = 'unset';
+      document.body.style.overflow = previousOverflow;
     };
   }, [isOpen]);
 
@@ -152,6 +151,7 @@ const LocationOverrideModal: React.FC<LocationOverrideModalProps> = ({
 
   return (
     <Box
+      className="app-modal-overlay"
       position="fixed"
       top={0}
       left={0}
@@ -166,6 +166,7 @@ const LocationOverrideModal: React.FC<LocationOverrideModalProps> = ({
       onClick={onClose}
     >
       <Box
+        className="app-modal-dialog"
         ref={modalRef}
         bg="white"
         borderRadius="20px"

--- a/src/components/LocationPermissionModal.tsx
+++ b/src/components/LocationPermissionModal.tsx
@@ -18,12 +18,13 @@ const LocationPermissionModal: React.FC<LocationPermissionModalProps> = ({
   const primaryActionRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
     if (isOpen) {
       document.body.style.overflow = 'hidden';
       primaryActionRef.current?.focus();
     }
     return () => {
-      document.body.style.overflow = 'auto';
+      document.body.style.overflow = previousOverflow;
     };
   }, [isOpen]);
 
@@ -52,23 +53,25 @@ const LocationPermissionModal: React.FC<LocationPermissionModalProps> = ({
 
   return (
     <div
+      className="app-modal-overlay"
       style={{
         position: 'fixed', inset: 0, zIndex: 1000,
         background: 'rgba(0,0,0,0.72)',
         backdropFilter: 'blur(6px)',
         WebkitBackdropFilter: 'blur(6px)',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
-        padding: '16px',
+        width: '100%', height: '100%', padding: 0, boxSizing: 'border-box',
       }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       onKeyDown={handleKeyDown}
     >
       <div
+        className="app-modal-dialog location-permission-dialog"
         style={{
           background: '#111318',
           border: '0.5px solid rgba(255,255,255,0.1)',
           borderRadius: '22px',
-          width: '100%', maxWidth: '480px',
+          width: 'calc(100% - 32px)', maxWidth: '480px', boxSizing: 'border-box',
           maxHeight: '90vh',
           overflow: 'hidden',
           display: 'flex', flexDirection: 'column',
@@ -82,7 +85,7 @@ const LocationPermissionModal: React.FC<LocationPermissionModalProps> = ({
           display: 'flex', alignItems: 'center', justifyContent: 'space-between',
           flexShrink: 0,
         }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', minWidth: 0 }}>
             <div style={{
               width: '40px', height: '40px', borderRadius: '10px',
               background: 'rgba(255,59,92,0.12)',
@@ -91,8 +94,8 @@ const LocationPermissionModal: React.FC<LocationPermissionModalProps> = ({
             }}>
               <AlertTriangle size={18} color="#ff3b5c" />
             </div>
-            <div>
-              <div style={{ fontSize: '16px', fontWeight: '700', color: '#f4f4f5', lineHeight: 1.2 }}>
+            <div style={{ minWidth: 0 }}>
+              <div id="location-permission-title" style={{ fontSize: '16px', fontWeight: '700', color: '#f4f4f5', lineHeight: 1.2 }}>
                 {t('location.permission.title', 'Location Access Required')}
               </div>
               <div style={{ fontSize: '11px', color: '#71717a', marginTop: '2px' }}>

--- a/src/components/LocationSearchButton.tsx
+++ b/src/components/LocationSearchButton.tsx
@@ -9,6 +9,7 @@ interface LocationSearchButtonProps {
 const LocationSearchButton: React.FC<LocationSearchButtonProps> = ({ onClick, top = '20px' }) => {
   return (
     <button
+      className="location-search-button"
       onClick={onClick}
       style={{
         position: 'absolute',
@@ -24,7 +25,7 @@ const LocationSearchButton: React.FC<LocationSearchButtonProps> = ({ onClick, to
         justifyContent: 'center',
         cursor: 'pointer',
         boxShadow: '0 4px 12px rgba(0,200,150,0.2)',
-        zIndex: 1000,
+        zIndex: 40,
         transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
         transform: 'translateY(0)',
       }}

--- a/src/components/LocationSearchModal.module.css
+++ b/src/components/LocationSearchModal.module.css
@@ -85,11 +85,7 @@
   font-size: 1.5rem;
   font-weight: 800;
   margin-bottom: 8px;
-  background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #334155 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  color: #0f172a;
   letter-spacing: -0.02em;
   line-height: 1.2;
   position: relative;
@@ -372,10 +368,7 @@
   font-weight: 700;
   color: #0f172a;
   margin-bottom: 6px;
-  background: linear-gradient(135deg, #0f172a 0%, #334155 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: #0f172a;
 }
 
 .loadingSubtext {

--- a/src/components/MapComponent.tsx
+++ b/src/components/MapComponent.tsx
@@ -94,29 +94,6 @@ const ControlButton: React.FC<{
   left?: string;
   variant?: 'default' | 'heatmap' | 'voice' | 'recenter';
 }> = ({ children, onClick, title, top, left, variant = 'default' }) => {
-  // Use theme variables for backgrounds
-  const getGradient = (variant: string) => {
-    switch (variant) {
-    case 'heatmap':
-      return 'linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%)';
-    case 'voice':
-      return 'linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%)';
-    case 'recenter':
-      return 'linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%)';
-    default:
-      return 'linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%)';
-    }
-  };
-
-  // Enhanced shadow with multiple layers using theme variables
-  const getShadow = (variant: string) => {
-    const baseShadow = 'var(--shadow-lg)';
-    if (variant === 'default') {
-      return `${baseShadow}, var(--shadow-sm)`;
-    }
-    return baseShadow;
-  };
-
   return (
     <button
       onClick={onClick}
@@ -128,43 +105,36 @@ const ControlButton: React.FC<{
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: getGradient(variant),
-        border: variant === 'default' ? '1px solid rgba(0,0,0,0.08)' : 'none',
+        background: 'rgba(255,255,255,0.96)',
+        border: '1px solid rgba(15, 23, 42, 0.08)',
         cursor: 'pointer',
         borderRadius: '12px',
-        boxShadow: getShadow(variant),
-        // Mobile touch improvements
+        boxShadow: '0 10px 24px rgba(15, 23, 42, 0.08)',
         WebkitTapHighlightColor: 'transparent',
         WebkitAppearance: 'none',
         touchAction: 'manipulation',
-        // Better accessibility
         minWidth: '44px',
         minHeight: '44px',
-        // Positioning
         position: 'absolute',
         top,
         ...(left ? { left } : { right: '10px' }),
-        zIndex: 1000,
-        // Modern transitions
-        transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
-        // Hover effects
+        zIndex: 40,
+        transition: 'transform 0.22s ease, box-shadow 0.22s ease, background 0.22s ease',
         transform: 'translateY(0)',
       }}
       onMouseEnter={(e) => {
-        e.currentTarget.style.transform = 'translateY(-2px) scale(1.05)';
-        e.currentTarget.style.boxShadow = variant === 'default'
-          ? '0 8px 25px rgba(0,0,0,0.15), 0 4px 10px rgba(0,0,0,0.1), 0 2px 4px rgba(0,0,0,0.05)'
-          : '0 8px 25px rgba(0,0,0,0.2), 0 4px 10px rgba(0,0,0,0.15)';
+        e.currentTarget.style.transform = 'translateY(-1px) scale(1.02)';
+        e.currentTarget.style.boxShadow = '0 12px 26px rgba(15, 23, 42, 0.12)';
       }}
       onMouseLeave={(e) => {
         e.currentTarget.style.transform = 'translateY(0) scale(1)';
-        e.currentTarget.style.boxShadow = getShadow(variant);
+        e.currentTarget.style.boxShadow = '0 10px 24px rgba(15, 23, 42, 0.08)';
       }}
       onMouseDown={(e) => {
         e.currentTarget.style.transform = 'translateY(0) scale(0.98)';
       }}
       onMouseUp={(e) => {
-        e.currentTarget.style.transform = 'translateY(-2px) scale(1.05)';
+        e.currentTarget.style.transform = 'translateY(-1px) scale(1.02)';
       }}
     >
       {children}
@@ -181,19 +151,19 @@ const RecenterControl: React.FC<{ userLocation: [number, number] | null }> = ({ 
       top="48px"
       variant="recenter"
     >
-      <Crosshair size={20} color="black" />
+      <Crosshair size={20} color="#0f172a" />
     </ControlButton>
   );
 };
 
-const HeatmapToggleControl: React.FC<{ isVisible: boolean, onToggle: () => void }> = ({ isVisible, onToggle }) => (
+const HeatmapToggleControl: React.FC<{ isVisible: boolean; onToggle: () => void }> = ({ onToggle }) => (
   <ControlButton
     onClick={onToggle}
     title="Toggle Heatmap"
     top="133px"
     variant="heatmap"
   >
-    <Layers size={20} color="black" />
+    <Layers size={20} color="#0f172a" />
   </ControlButton>
 );
 
@@ -216,7 +186,7 @@ const ZoomInControl: React.FC = () => {
       left="10px"
       variant="default"
     >
-      <ZoomIn size={20} color="var(--text-primary)" />
+      <ZoomIn size={20} color="#0f172a" />
     </ControlButton>
   );
 };
@@ -231,7 +201,7 @@ const ZoomOutControl: React.FC = () => {
       left="10px"
       variant="default"
     >
-      <ZoomOut size={20} color="var(--text-primary)" />
+      <ZoomOut size={20} color="#0f172a" />
     </ControlButton>
   );
 };
@@ -592,7 +562,7 @@ const VibeMarker: React.FC<{
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 10, scale: 0.9 }}
             className="absolute bottom-full left-1/2 -translate-x-1/2 mb-4 w-72 rounded-2xl shadow-2xl p-4"
-            style={{ background: 'var(--bg-surface)', border: '0.5px solid var(--wire)' }}
+            style={{ background: 'rgba(255,255,255,0.98)', border: '0.5px solid var(--wire)' }}
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
@@ -620,7 +590,7 @@ const VibeMarker: React.FC<{
             )}
 
             {/* Actions */}
-            <div className="flex items-center gap-4 pt-3 border-t border-gray-100 dark:border-gray-800">
+            <div className="flex items-center gap-4 pt-3 border-t border-gray-100">
               <motion.button
                 whileTap={{ scale: 0.9 }}
                 onClick={() => {
@@ -663,7 +633,7 @@ const SOSMarker: React.FC<{
       icon={sosIcon}
     >
       <Popup>
-        <div style={{ color: 'var(--t1)', maxWidth: '320px', background: 'var(--bg-surface)', padding: '8px 0' }}>
+        <div style={{ color: 'var(--t1)', maxWidth: '320px', background: 'rgba(255,255,255,0.98)', padding: '8px 0' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '8px' }}>
             <div>
               <strong style={{ color: 'var(--t1)' }}>🚨 SOS Alert!</strong>
@@ -730,10 +700,10 @@ const OtherUserMarker: React.FC<{
       <Popup>
         <div style={{
           padding: '16px',
-          background: 'var(--bg-primary)',
+          background: 'rgba(255,255,255,0.98)',
           borderRadius: '8px',
           boxShadow: 'var(--shadow-lg)',
-          border: '1px solid var(--border-color)',
+          border: '1px solid rgba(15, 23, 42, 0.08)',
           maxWidth: '280px',
         }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
@@ -860,8 +830,8 @@ const MapComponent: React.FC<MapComponentProps> = React.memo(({
 
   return (
     <>
-
-      <MapContainer center={center} zoom={zoom} scrollWheelZoom={true} style={{ height: '100%', width: '100%', background: '#09090b' }}>
+      <div className="map-view-shell" style={{ position: 'relative', width: '100%', minHeight: 'calc(100dvh - 168px)', height: 'calc(100dvh - 168px)' }}>
+        <MapContainer center={center} zoom={zoom} scrollWheelZoom={true} style={{ height: '100%', width: '100%', minHeight: '100%', background: '#f6f7fb' }}>
         <MapFlyController center={center} zoom={zoom} />
         <SearchFlyController searchLocation={searchLocation} />
         <TargetLocationController targetLocation={targetLocation} />
@@ -874,7 +844,7 @@ const MapComponent: React.FC<MapComponentProps> = React.memo(({
 
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
-          url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+          url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
           maxZoom={20}
         />
         {userLocation && (
@@ -885,10 +855,10 @@ const MapComponent: React.FC<MapComponentProps> = React.memo(({
             <Popup>
               <div style={{
                 padding: '20px',
-                background: 'var(--bg-primary)',
+                background: 'rgba(255,255,255,0.98)',
                 borderRadius: '12px',
                 boxShadow: 'var(--shadow-lg)',
-                border: '1px solid var(--border-color)',
+                border: '1px solid rgba(15, 23, 42, 0.08)',
                 maxWidth: '280px',
                 whiteSpace: 'nowrap',
               }}>
@@ -925,10 +895,10 @@ const MapComponent: React.FC<MapComponentProps> = React.memo(({
             <Popup className="custom-popup">
               <div style={{
                 padding: '16px',
-                background: 'var(--bg-primary)',
+                background: 'rgba(255,255,255,0.98)',
                 borderRadius: '8px',
                 boxShadow: 'var(--shadow-lg)',
-                border: '1px solid var(--border-color)',
+                border: '1px solid rgba(15, 23, 42, 0.08)',
                 maxWidth: '320px',
               }}>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
@@ -1004,16 +974,11 @@ const MapComponent: React.FC<MapComponentProps> = React.memo(({
       />
 
       {/* Vibe Legend */}
-      <VibeLegend />
+        <VibeLegend />
 
-      {/* Vibe Legend */}
-      <VibeLegend />
-
-      {/* Vibe Legend */}
-      <VibeLegend />
-
-      {/* Dynamic Safety Waves Overlay */}
-      <SafetyWaveOverlay vibes={validVibes} />
+        {/* Dynamic Safety Waves Overlay */}
+        <SafetyWaveOverlay vibes={validVibes} />
+      </div>
     </>
   );
 });

--- a/src/components/MapMarker.tsx
+++ b/src/components/MapMarker.tsx
@@ -93,18 +93,18 @@ export function MapMarker({ vibe, style, onClick, onVote }: MapMarkerProps) {
             initial={{ opacity: 0, y: 10, scale: 0.9 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 10, scale: 0.9 }}
-            className="absolute bottom-full left-1/2 -translate-x-1/2 mb-4 w-80 bg-white dark:bg-gray-900 rounded-2xl shadow-2xl p-4 border border-gray-200 dark:border-gray-800 z-50"
+            className="absolute bottom-full left-1/2 -translate-x-1/2 mb-4 w-80 bg-white rounded-2xl shadow-2xl p-4 border border-gray-200 z-50"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header with user info */}
             <div className="flex items-center gap-3 mb-3">
-              <div className="w-10 h-10 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center">
-                <span className="text-sm font-medium text-gray-600 dark:text-gray-300">
+              <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
+                <span className="text-sm font-medium text-gray-600">
                   {vibe.profile?.username?.[0]?.toUpperCase() || 'U'}
                 </span>
               </div>
               <div className="flex-1">
-                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                <p className="text-sm font-medium text-gray-900">
                   {vibe.profile?.username || 'Anonymous'}
                 </p>
                 <div className="flex items-center gap-1 text-xs text-gray-500">
@@ -119,20 +119,20 @@ export function MapMarker({ vibe, style, onClick, onVote }: MapMarkerProps) {
 
             {/* Content */}
             {vibe.notes && (
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 leading-relaxed">
+              <p className="text-sm text-gray-600 mb-3 leading-relaxed">
                 {vibe.notes}
               </p>
             )}
 
             {/* Action buttons */}
-            <div className="flex items-center gap-4 pt-3 border-t border-gray-100 dark:border-gray-800">
+            <div className="flex items-center gap-4 pt-3 border-t border-gray-100">
               <motion.button
                 whileTap={{ scale: 0.9 }}
                 onClick={handleVote}
                 className={`flex items-center gap-1 text-sm transition-colors min-h-[44px] px-2 py-1 rounded-lg ${
                   isVoted
                     ? 'text-red-500 hover:text-red-600'
-                    : 'text-gray-600 hover:text-red-500 dark:text-gray-400 dark:hover:text-red-400'
+                    : 'text-gray-600 hover:text-red-500'
                 }`}
               >
                 <Heart className={`w-4 h-4 ${isVoted ? 'fill-current' : ''}`} />
@@ -142,7 +142,7 @@ export function MapMarker({ vibe, style, onClick, onVote }: MapMarkerProps) {
               <motion.button
                 whileTap={{ scale: 0.9 }}
                 onClick={handleComment}
-                className="flex items-center gap-1 text-sm text-gray-600 hover:text-blue-500 transition-colors min-h-[44px] px-2 py-1 rounded-lg dark:text-gray-400 dark:hover:text-blue-400"
+                className="flex items-center gap-1 text-sm text-gray-600 hover:text-blue-500 transition-colors min-h-[44px] px-2 py-1 rounded-lg"
               >
                 <MessageCircle className="w-4 h-4" />
                 <span>Comment</span>

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -13,7 +13,6 @@ import type { User } from '../types';
 import { INTEREST_CATEGORIES } from '../types';
 
 import { LoadingSpinner } from './shared';
-import TranslationTest from './TranslationTest';
 import EditProfileModal from './EditProfileModal';
 
 
@@ -693,15 +692,16 @@ const ProfileView: React.FC = () => {
   };
 
   return (
-    <Box maxW="500px" mx="auto" bg="var(--bg-base)" minH="100vh" position="relative" borderX="1px solid" borderColor="var(--wire)" style={{ color: 'var(--t1)' }}>
+    <Box className="page-view page-view--profile" maxW="920px" w="full" mx="auto" bg="var(--bg-base)" minH="100%" position="relative" borderX="1px solid" borderColor="var(--wire)" style={{ color: 'var(--t1)' }}>
       {/* Header */}
       <Box
+        className="page-view__header"
         bg="var(--bg-surface)"
         color="var(--t1)"
         p={6}
         position="sticky"
         top={0}
-        zIndex={100}
+        zIndex={20}
         borderBottom="1px solid"
         borderColor="gray.200"
         boxShadow="0 1px 3px rgba(0, 0, 0, 0.05)"

--- a/src/components/SafetyWaveOverlay.tsx
+++ b/src/components/SafetyWaveOverlay.tsx
@@ -144,12 +144,12 @@ const SafetyWaveOverlay: React.FC<SafetyWaveOverlayProps> = ({ vibes, className 
     <div
       className={`safety-particle-overlay ${className}`}
       style={{
-        position: 'fixed',
-        bottom: '0', // At very bottom, overlaying everything
+        position: 'absolute',
+        bottom: 0,
         left: 0,
         right: 0,
-        height: '120px', // Increased height for better particle spread
-        zIndex: 100, // Above both map and tab navigation
+        height: '96px',
+        zIndex: 20,
         pointerEvents: 'none',
         overflow: 'hidden',
       }}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Box, VStack, HStack, Text, Button, Grid, GridItem, Select } from '@chakra-ui/react';
+import { Box, VStack, HStack, Text, Button } from '@chakra-ui/react';
 import { Capacitor } from '@capacitor/core';
-import { Settings, UserCog, Sliders, Shield, Info, LogOut, Key, Trash, Globe, Bell, Users, MapPin, FileText, ShieldCheck } from 'lucide-react';
+import { AlertTriangle, Settings, UserCog, Sliders, Shield, LogOut, Key, Trash, Bell, MapPin, FileText, ShieldCheck, X } from 'lucide-react';
 
 import { useAuth } from '../contexts/AuthContext';
-import { useLanguage } from '../contexts/LanguageContext';
 import { useSettings } from '../contexts/SettingsContext';
-import { useTheme } from '../contexts/ThemeContext';
 import { authService } from '../services/auth';
 import { pushNotificationService } from '../services/pushNotificationService';
 import { notificationService } from '../services/notificationService';
@@ -16,17 +14,13 @@ import { storageManager } from '../lib/storage';
 import ToggleSwitch from './shared/ToggleSwitch';
 import PrivacyPolicyModal from './PrivacyPolicyModal';
 import TermsOfServiceModal from './TermsOfServiceModal';
-import MarketingEmailAdmin from './MarketingEmailAdmin';
 
 
 const SettingsView: React.FC = () => {
   const { t } = useTranslation();
-  const { user, signOut, updateProfile } = useAuth();
-  const { currentLanguage, changeLanguage, isChanging } = useLanguage();
+  const { user, signOut } = useAuth();
   const { settings, updateSettings, isLoading: settingsLoading } = useSettings();
-  const { theme } = useTheme();
 
-  const [selectedLanguage, setSelectedLanguage] = useState(currentLanguage);
   const [showPasswordModal, setShowPasswordModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [passwordForm, setPasswordForm] = useState({
@@ -37,21 +31,11 @@ const SettingsView: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [showPrivacyPolicyModal, setShowPrivacyPolicyModal] = useState(false);
   const [showTermsOfServiceModal, setShowTermsOfServiceModal] = useState(false);
-  const [showMarketingEmailAdmin, setShowMarketingEmailAdmin] = useState(false);
   const [showLocationSharingAgreement, setShowLocationSharingAgreement] = useState(false);
   const [notificationPermissionStatus, setNotificationPermissionStatus] = useState<'granted' | 'denied' | 'default' | 'unknown'>('unknown');
   const [locationPermissionStatus, setLocationPermissionStatus] = useState<'granted' | 'denied' | 'prompt' | 'unknown'>('unknown');
   const [isRequestingPermission, setIsRequestingPermission] = useState(false);
-
-  const languages = [
-    { code: 'en', name: 'English' },
-    { code: 'ar', name: 'العربية' },
-  ];
-
-  // Sync selectedLanguage with currentLanguage
-  useEffect(() => {
-    setSelectedLanguage(currentLanguage);
-  }, [currentLanguage]);
+  const [preferenceStatus, setPreferenceStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
 
   // Check permission statuses on mount
   useEffect(() => {
@@ -76,6 +60,11 @@ const SettingsView: React.FC = () => {
   }, []);
 
   const handlePasswordChange = async () => {
+    if (!passwordForm.currentPassword) {
+      alert('Enter your current password.');
+      return;
+    }
+
     if (passwordForm.newPassword !== passwordForm.confirmPassword) {
       alert(t('settings.passwordsNotMatch'));
       return;
@@ -88,6 +77,11 @@ const SettingsView: React.FC = () => {
 
     setLoading(true);
     try {
+      if (!user?.email) {
+        throw new Error('No signed-in email address was found.');
+      }
+
+      await authService.signIn(user.email, passwordForm.currentPassword);
       const { error } = await authService.updatePassword(passwordForm.newPassword);
       if (error) {
         alert('Error updating password: ' + error.message);
@@ -103,9 +97,16 @@ const SettingsView: React.FC = () => {
     }
   };
 
-  const handleLanguageChange = async (language: string) => {
-    setSelectedLanguage(language);
-    await changeLanguage(language, updateProfile, user);
+  const persistSettings = async (updates: Parameters<typeof updateSettings>[0]) => {
+    setPreferenceStatus('saving');
+    try {
+      await updateSettings(updates);
+      setPreferenceStatus('saved');
+    } catch (error) {
+      console.error('Error saving preferences:', error);
+      setPreferenceStatus('error');
+      throw error;
+    }
   };
 
   const handleLogout = async () => {
@@ -118,14 +119,6 @@ const SettingsView: React.FC = () => {
 
   const handleDeleteAccount = async () => {
     if (!user) {
-      return;
-    }
-
-    const confirmDelete = window.confirm(
-      t('settings.deleteConfirmMessage'),
-    );
-
-    if (!confirmDelete) {
       return;
     }
 
@@ -149,43 +142,42 @@ const SettingsView: React.FC = () => {
   const handleNotificationToggle = async (enabled: boolean) => {
     setIsRequestingPermission(true);
 
-    if (enabled) {
-      if (user?.id) {
-        await storageManager.remove(`notificationPermissionRequested_${user.id}`);
-      }
-
-      if (notificationPermissionStatus !== 'granted') {
-        try {
-          // TODO: Implement with Capacitor push notifications
-          if (user?.id) {
-            await pushNotificationService.initialize(user.id);
-            setNotificationPermissionStatus('granted');
-            updateSettings({ notifications: true });
-          } else {
-            setNotificationPermissionStatus('denied');
-            updateSettings({ notifications: false });
-          }
-        } catch (error) {
-          console.error('Notification permission error:', error);
-          setNotificationPermissionStatus('denied');
-          updateSettings({ notifications: false });
+    try {
+      if (enabled) {
+        if (user?.id) {
+          await storageManager.remove(`notificationPermissionRequested_${user.id}`);
         }
+
+        let permissionGranted = notificationPermissionStatus === 'granted';
+
+        if (!permissionGranted && Capacitor.isNativePlatform() && user?.id) {
+          await pushNotificationService.initialize(user.id);
+          permissionGranted = true;
+        } else if (!permissionGranted && 'Notification' in window) {
+          const permission = await Notification.requestPermission();
+          setNotificationPermissionStatus(permission);
+          permissionGranted = permission === 'granted';
+        }
+
+        if (permissionGranted) {
+          await pushNotificationService.updatePreferences({
+            emergency_alerts: true,
+            safety_reports: true,
+          });
+        }
+        await persistSettings({ notifications: permissionGranted });
       } else {
-        updateSettings({ notifications: true });
-      }
-    } else {
-      updateSettings({ notifications: false });
-      try {
         await pushNotificationService.updatePreferences({
           emergency_alerts: false,
           safety_reports: false,
         });
-      } catch (error) {
-        console.error('Error updating push notification preferences:', error);
+        await persistSettings({ notifications: false });
       }
+    } catch (error) {
+      console.error('Notification preference could not be saved:', error);
+    } finally {
+      setIsRequestingPermission(false);
     }
-
-    setIsRequestingPermission(false);
   };
 
   const handleLocationToggle = async (enabled: boolean) => {
@@ -194,13 +186,17 @@ const SettingsView: React.FC = () => {
       setShowLocationSharingAgreement(true);
     } else {
       // Disable location sharing immediately
-      updateSettings({ locationSharing: false });
+      try {
+        await persistSettings({ locationSharing: false });
+      } catch {
+        // The context restores the previous value when the server write fails.
+      }
     }
   };
 
   const confirmLocationSharing = async () => {
     setShowLocationSharingAgreement(false);
-    updateSettings({ locationSharing: true });
+    let permissionGranted = locationPermissionStatus === 'granted';
 
     // Request location permission if not already granted
     if (locationPermissionStatus !== 'granted') {
@@ -210,6 +206,7 @@ const SettingsView: React.FC = () => {
             navigator.geolocation.getCurrentPosition(
               () => {
                 setLocationPermissionStatus('granted');
+                permissionGranted = true;
                 resolve(void 0);
               },
               (error) => {
@@ -221,8 +218,20 @@ const SettingsView: React.FC = () => {
           });
         } catch (error) {
           setLocationPermissionStatus('denied');
+          permissionGranted = false;
         }
       }
+    }
+
+    if (!permissionGranted) {
+      setPreferenceStatus('error');
+      return;
+    }
+
+    try {
+      await persistSettings({ locationSharing: true });
+    } catch {
+      return;
     }
 
     if (user?.id) {
@@ -231,269 +240,370 @@ const SettingsView: React.FC = () => {
   };
 
   return (
-    <Box maxW="500px" mx="auto" bg="var(--bg-base)" minH="100vh" position="relative" borderX="1px solid" borderColor="var(--wire)" style={{ color: 'var(--t1)' }}>
+    <Box className="page-view page-view--settings" maxW="920px" w="full" mx="auto" bg="#f4f5f2" minH="100%" position="relative" borderX="1px solid" borderColor="var(--wire)" style={{ color: 'var(--t1)' }}>
       {/* Header */}
       <Box
+        className="page-view__header"
         bg="var(--bg-surface)"
         color="var(--t1)"
-        p={6}
+        px={{ base: 4, md: 6 }}
+        py={{ base: 4, md: 5 }}
         position="sticky"
         top={0}
-        zIndex={100}
+        zIndex={20}
         borderBottom="1px solid"
         borderColor="gray.200"
-        boxShadow="0 1px 3px rgba(0, 0, 0, 0.05)"
+        boxShadow="0 1px 0 rgba(15, 23, 42, 0.02)"
       >
-        <VStack justify="center" align="center">
-          <Text fontSize="24px" fontWeight="700" letterSpacing="-0.5px" lineHeight="1.2">
-            {t('settings.title')}
-          </Text>
-          <Text fontSize="14px" color="gray.700" mt={2} letterSpacing="0.5px" fontWeight="500">
-            {t('settings.subtitle')}
-          </Text>
-        </VStack>
+        <HStack gap={3.5} align="center">
+          <Box
+            w={{ base: '40px', md: '44px' }}
+            h={{ base: '40px', md: '44px' }}
+            flexShrink={0}
+            borderRadius="13px"
+            bg="#111318"
+            color="white"
+            display="grid"
+            placeItems="center"
+            boxShadow="0 9px 22px rgba(17, 19, 24, 0.16)"
+          >
+            <Settings size={18} />
+          </Box>
+          <Box minW={0}>
+            <Text fontSize={{ base: '20px', md: '23px' }} fontWeight="750" letterSpacing="-0.5px" lineHeight="1.15">
+              {t('settings.title')}
+            </Text>
+            <Text fontSize="12px" color="gray.500" mt={1} letterSpacing="0.1px" fontWeight="500">
+              {t('settings.subtitle')}
+            </Text>
+          </Box>
+        </HStack>
       </Box>
 
       {/* Main Content */}
-      <Box p={6} minH="calc(100vh - 180px)">
+      <Box
+        px={{ base: 3, md: 6 }}
+        pt={{ base: 4, md: 5 }}
+        pb={{ base: 'calc(var(--app-mobile-nav-height) + 20px)', lg: 5 }}
+        minH="calc(100vh - 180px)"
+      >
         <VStack gap={4} align="stretch">
           {/* Account Management Section */}
-          <Box bg="white" borderRadius="16px" p={5} border="1px solid" borderColor="gray.200" boxShadow="0 2px 8px rgba(0, 0, 0, 0.04)" mb={4}>
-            <HStack justify="space-between" align="center" mb={5}>
+          <Box
+            bg="white"
+            borderRadius="16px"
+            border="1px solid"
+            borderColor="gray.200"
+            boxShadow="0 2px 8px rgba(0, 0, 0, 0.04)"
+            overflow="hidden"
+          >
+            <HStack justify="space-between" align="center" px={5} py={4}>
               <HStack gap={3}>
-                <Box w="40px" h="40px" borderRadius="12px" bg="gray.100" display="flex" alignItems="center" justifyContent="center">
-                  <UserCog size={18} />
+                <Box w="36px" h="36px" borderRadius="11px" bg="gray.100" display="flex" alignItems="center" justifyContent="center">
+                  <UserCog size={16} />
                 </Box>
-                <Text fontWeight="600" fontSize="16px">{t('settings.accountManagementTitle')}</Text>
+                <Box>
+                  <Text fontWeight="650" fontSize="15px">{t('settings.accountManagementTitle')}</Text>
+                  <Text fontSize="11px" color="gray.500" mt={0.5}>{t('settings.accountDescription', 'Security and account access')}</Text>
+                </Box>
               </HStack>
             </HStack>
 
-            <VStack gap={3} align="stretch">
+            <VStack gap={0} align="stretch" borderTop="1px solid" borderColor="gray.100">
               {/* Change Password */}
-              <HStack gap={3} w="full">
-                <Box w="12" h="12" borderRadius="8px" bg="blue.100" display="flex" alignItems="center" justifyContent="center">
-                  <Key size={16} color="#2563eb" />
-                </Box>
+              <HStack gap={4} w="full" minH="82px" px={{ base: 4, md: 5 }} py={4} justify="space-between" align="center">
+                <HStack gap={3} minW={0} flex={1} align="center">
+                  <Box
+                    w="36px"
+                    h="36px"
+                    flexShrink={0}
+                    borderRadius="10px"
+                    bg="blue.50"
+                    border="1px solid"
+                    borderColor="blue.100"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    <Key size={15} color="#2563eb" />
+                  </Box>
+                  <Box minW={0}>
+                    <Text fontSize="14px" fontWeight="650" color="gray.900">
+                      {t('settings.passwordTitle', 'Password')}
+                    </Text>
+                    <Text mt={0.5} fontSize="12px" lineHeight="1.45" color="gray.500">
+                      {t('settings.passwordDescription', 'Update your password and keep your account secure.')}
+                    </Text>
+                  </Box>
+                </HStack>
                 <Button
-                  bg="blue.500"
-                  color="white"
-                  borderRadius="12px"
-                  px={4}
-                  py={3}
-                  fontSize="16px"
+                  size="sm"
+                  variant="outline"
+                  h="34px"
+                  minW={{ base: '112px', md: '132px' }}
+                  flexShrink={0}
+                  borderRadius="9px"
+                  borderColor="gray.300"
+                  bg="white"
+                  color="gray.800"
+                  px={3}
+                  fontSize="12px"
                   fontWeight="600"
                   onClick={() => setShowPasswordModal(true)}
-                  _hover={{ bg: 'blue.600', transform: 'translateY(-1px)' }}
-                  _active={{ transform: 'translateY(0)' }}
+                  _hover={{ bg: 'gray.50', borderColor: 'gray.400' }}
+                  _active={{ bg: 'gray.100' }}
                   transition="all 0.2s"
-                  flex={1}
                 >
-                  {t('settings.changePasswordButton')}
+                  {t('settings.changePasswordButton', 'Change password')}
                 </Button>
               </HStack>
 
               {/* Delete Account */}
-              <HStack gap={3} w="full">
-                <Box w="12" h="12" borderRadius="8px" bg="red.100" display="flex" alignItems="center" justifyContent="center">
-                  <Trash size={16} color="#dc2626" />
-                </Box>
+              <HStack
+                gap={4}
+                w="full"
+                minH="82px"
+                px={{ base: 4, md: 5 }}
+                py={4}
+                justify="space-between"
+                align="center"
+                borderTop="1px solid"
+                borderColor="red.100"
+                bg="rgba(254, 242, 242, 0.48)"
+              >
+                <HStack gap={3} minW={0} flex={1} align="center">
+                  <Box
+                    w="36px"
+                    h="36px"
+                    flexShrink={0}
+                    borderRadius="10px"
+                    bg="red.50"
+                    border="1px solid"
+                    borderColor="red.100"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    <Trash size={15} color="#dc2626" />
+                  </Box>
+                  <Box minW={0}>
+                    <Text fontSize="14px" fontWeight="650" color="gray.900">
+                      {t('settings.deleteAccountTitle', 'Delete account')}
+                    </Text>
+                    <Text mt={0.5} fontSize="12px" lineHeight="1.45" color="gray.500">
+                      {t('settings.deleteAccountDescription', 'Permanently remove your account and all saved data.')}
+                    </Text>
+                  </Box>
+                </HStack>
                 <Button
-                  bg="red.500"
-                  color="white"
-                  borderRadius="12px"
-                  px={4}
-                  py={3}
-                  fontSize="16px"
+                  size="sm"
+                  variant="outline"
+                  h="34px"
+                  minW={{ base: '112px', md: '132px' }}
+                  flexShrink={0}
+                  borderRadius="9px"
+                  borderColor="red.300"
+                  bg="white"
+                  color="red.600"
+                  px={3}
+                  fontSize="12px"
                   fontWeight="600"
                   onClick={() => setShowDeleteModal(true)}
-                  _hover={{ bg: 'red.600', transform: 'translateY(-1px)' }}
-                  _active={{ transform: 'translateY(0)' }}
+                  _hover={{ bg: 'red.50', borderColor: 'red.400' }}
+                  _active={{ bg: 'red.100' }}
                   transition="all 0.2s"
-                  flex={1}
                 >
-                  {t('settings.deleteAccountButton')}
+                  {t('settings.deleteAccountButton', 'Delete account')}
                 </Button>
               </HStack>
             </VStack>
           </Box>
 
           {/* App Preferences Section */}
-          <Box bg="white" borderRadius="16px" p={5} border="1px solid" borderColor="gray.200" boxShadow="0 2px 8px rgba(0, 0, 0, 0.04)" mb={4}>
-            <HStack justify="space-between" align="center" mb={5}>
+          <Box bg="white" borderRadius="16px" border="1px solid" borderColor="gray.200" boxShadow="0 2px 8px rgba(0, 0, 0, 0.04)" overflow="hidden">
+            <HStack justify="space-between" align="center" px={5} py={4}>
               <HStack gap={3}>
-                <Box w="40px" h="40px" borderRadius="12px" bg="gray.100" display="flex" alignItems="center" justifyContent="center">
-                  <Sliders size={18} />
+                <Box w="36px" h="36px" borderRadius="11px" bg="gray.100" display="flex" alignItems="center" justifyContent="center">
+                  <Sliders size={16} />
                 </Box>
-                <Text fontWeight="600" fontSize="16px">{t('settings.appPreferencesTitle')}</Text>
+                <Box>
+                  <Text fontWeight="650" fontSize="15px">{t('settings.appPreferencesTitle')}</Text>
+                  <Text fontSize="11px" color="gray.500" mt={0.5}>{t('settings.preferencesDescription', 'Notification and location preferences')}</Text>
+                </Box>
               </HStack>
+              <Text
+                aria-live="polite"
+                minW="54px"
+                px={2.5}
+                py={1}
+                borderRadius="full"
+                textAlign="center"
+                fontSize="10px"
+                fontWeight="650"
+                color={preferenceStatus === 'error' ? 'red.700' : preferenceStatus === 'saved' ? 'green.700' : 'gray.500'}
+                bg={preferenceStatus === 'error' ? 'red.50' : preferenceStatus === 'saved' ? 'green.50' : 'gray.50'}
+                visibility={preferenceStatus === 'idle' ? 'hidden' : 'visible'}
+              >
+                {preferenceStatus === 'saving' && 'Saving…'}
+                {preferenceStatus === 'saved' && 'Saved'}
+                {preferenceStatus === 'error' && 'Retry'}
+              </Text>
             </HStack>
 
-            <VStack gap={4} align="stretch">
-              {/* Language Selection */}
-              <Box bg="gray.50" borderRadius="12px" p={4} border="1px solid" borderColor="gray.200">
-                <HStack justify="space-between" align="center">
-                  <HStack gap={3}>
-                    <Box w="10" h="10" borderRadius="8px" bg="blue.100" display="flex" alignItems="center" justifyContent="center">
-                      <Globe size={16} color="#2563eb" />
-                    </Box>
-                    <Box>
-                      <Text fontSize="14px" fontWeight="600" color="gray.900">{t('settings.languageTitle')}</Text>
-                      <Text fontSize="12px" color="gray.600">{t('settings.languageDescription')}</Text>
-                    </Box>
-                  </HStack>
-                  <select
-                    value={selectedLanguage}
-                    onChange={(e) => handleLanguageChange(e.target.value)}
-                    disabled={isChanging}
-                    style={{
-                      padding: '6px 12px',
-                      border: '1px solid #d1d5db',
-                      borderRadius: '8px',
-                      backgroundColor: isChanging ? '#f3f4f6' : 'white',
-                      color: isChanging ? '#6b7280' : '#111827',
-                      fontSize: '14px',
-                      fontWeight: '500',
-                      cursor: isChanging ? 'not-allowed' : 'pointer',
-                      minWidth: '120px',
-                      opacity: isChanging ? 0.6 : 1,
-                    }}
-                  >
-                    {languages.map(lang => (
-                      <option key={lang.code} value={lang.code}>
-                        {lang.name}
-                      </option>
-                    ))}
-                  </select>
-                </HStack>
-              </Box>
-
+            <VStack gap={0} align="stretch" borderTop="1px solid" borderColor="gray.100">
               {/* Notifications */}
-              <Box bg="gray.50" borderRadius="12px" p={4} border="1px solid" borderColor="gray.200">
-                <HStack justify="space-between" align="center">
-                  <HStack gap={3}>
-                    <Box w="10" h="10" borderRadius="8px" bg="orange.100" display="flex" alignItems="center" justifyContent="center">
-                      <Bell size={16} color="#d97706" />
-                    </Box>
-                    <Box>
-                      <Text fontSize="14px" fontWeight="600" color="gray.900">{t('settings.notificationsTitle')}</Text>
-                      {notificationPermissionStatus === 'denied' && (
-                        <Text fontSize="11px" color="red.600">{t('settings.notificationsPermissionDenied')}</Text>
-                      )}
-                    </Box>
-                  </HStack>
-                  <ToggleSwitch
-                    checked={settings.notifications && notificationPermissionStatus === 'granted'}
-                    onChange={handleNotificationToggle}
-                    disabled={isRequestingPermission}
-                    size="md"
-                  />
+              <HStack justify="space-between" align="center" gap={4} minH="76px" px={{ base: 4, md: 5 }} py={3.5}>
+                <HStack gap={3} minW={0} flex={1}>
+                  <Box w="36px" h="36px" flexShrink={0} borderRadius="10px" bg="orange.50" border="1px solid" borderColor="orange.100" display="flex" alignItems="center" justifyContent="center">
+                    <Bell size={15} color="#d97706" />
+                  </Box>
+                  <Box minW={0}>
+                    <Text fontSize="14px" fontWeight="650" color="gray.900">{t('settings.notificationsTitle')}</Text>
+                    <Text fontSize="12px" color={notificationPermissionStatus === 'denied' ? 'red.600' : 'gray.500'} lineHeight="1.4">
+                      {notificationPermissionStatus === 'denied'
+                        ? t('settings.notificationsPermissionDenied')
+                        : t('settings.notificationsDescription', 'Choose whether HyperApp can send you updates.')}
+                    </Text>
+                  </Box>
                 </HStack>
-              </Box>
-
-
+                <ToggleSwitch
+                  checked={settings.notifications && notificationPermissionStatus === 'granted'}
+                  onChange={handleNotificationToggle}
+                  disabled={isRequestingPermission || settingsLoading}
+                  size="md"
+                />
+              </HStack>
             </VStack>
           </Box>
 
           {/* Privacy & Security Section */}
-          <Box bg="white" borderRadius="16px" p={5} border="1px solid" borderColor="gray.200" boxShadow="0 2px 8px rgba(0, 0, 0, 0.04)" mb={4}>
-            <HStack justify="space-between" align="center" mb={5}>
+          <Box bg="white" borderRadius="16px" border="1px solid" borderColor="gray.200" boxShadow="0 2px 8px rgba(0, 0, 0, 0.04)" overflow="hidden">
+            <HStack justify="space-between" align="center" px={5} py={4}>
               <HStack gap={3}>
-                <Box w="40px" h="40px" borderRadius="12px" bg="gray.100" display="flex" alignItems="center" justifyContent="center">
-                  <Shield size={18} />
+                <Box w="36px" h="36px" borderRadius="11px" bg="gray.100" display="flex" alignItems="center" justifyContent="center">
+                  <Shield size={16} />
                 </Box>
-                <Text fontWeight="600" fontSize="16px">{t('settings.privacySecurityTitle')}</Text>
+                <Box>
+                  <Text fontWeight="650" fontSize="15px">{t('settings.privacySecurityTitle')}</Text>
+                  <Text fontSize="11px" color="gray.500" mt={0.5}>{t('settings.privacyDescription', 'Privacy, legal, and application information')}</Text>
+                </Box>
               </HStack>
             </HStack>
 
-            <VStack gap={4} align="stretch">
+            <VStack gap={0} align="stretch" borderTop="1px solid" borderColor="gray.100">
               {/* Location Sharing */}
-              <Box bg="gray.50" borderRadius="12px" p={4} border="1px solid" borderColor="gray.200">
-                <HStack justify="space-between" align="center">
-                  <HStack gap={3}>
-                    <Box w="10" h="10" borderRadius="8px" bg="green.100" display="flex" alignItems="center" justifyContent="center">
-                      <MapPin size={16} color="#059669" />
-                    </Box>
-                    <Box>
-                      <Text fontSize="14px" fontWeight="600" color="gray.900">{t('settings.locationSharingTitle')}</Text>
-                      <Text fontSize="12px" color="gray.600">Share your location and see other community members on the map</Text>
-                    </Box>
-                  </HStack>
-                  <ToggleSwitch
-                    checked={settings.locationSharing}
-                    onChange={handleLocationToggle}
-                    size="md"
-                  />
+              <HStack justify="space-between" align="center" gap={4} minH="76px" px={{ base: 4, md: 5 }} py={3.5}>
+                <HStack gap={3} minW={0} flex={1}>
+                  <Box w="36px" h="36px" flexShrink={0} borderRadius="10px" bg="green.50" border="1px solid" borderColor="green.100" display="flex" alignItems="center" justifyContent="center">
+                    <MapPin size={15} color="#059669" />
+                  </Box>
+                  <Box minW={0}>
+                    <Text fontSize="14px" fontWeight="650" color="gray.900">{t('settings.locationSharingTitle')}</Text>
+                    <Text fontSize="12px" color="gray.500" lineHeight="1.4">{t('settings.locationSharingDescription', 'Share your location and see community members on the map.')}</Text>
+                  </Box>
                 </HStack>
-              </Box>
+                <ToggleSwitch
+                  checked={settings.locationSharing}
+                  onChange={handleLocationToggle}
+                  disabled={settingsLoading || preferenceStatus === 'saving'}
+                  size="md"
+                />
+              </HStack>
+
               {/* App Version */}
-              <Box bg="gray.50" borderRadius="12px" p={4} border="1px solid" borderColor="gray.200" textAlign="center">
-                <Box w="16" h="16" borderRadius="12px" bg="blue.500" display="flex" alignItems="center" justifyContent="center" mx="auto" mb={3}>
-                  <Settings size={20} color="white" />
-                </Box>
-                <Text fontSize="18px" fontWeight="700" color="gray.900" mb={1}>{t('settings.version')}</Text>
-                <Text fontSize="14px" color="gray.600">{t('settings.appDescription')}</Text>
-              </Box>
+              <HStack justify="space-between" align="center" gap={4} minH="72px" px={{ base: 4, md: 5 }} py={3.5} borderTop="1px solid" borderColor="gray.100">
+                <HStack gap={3} minW={0} flex={1}>
+                  <Box w="36px" h="36px" flexShrink={0} borderRadius="10px" bg="gray.100" border="1px solid" borderColor="gray.200" display="flex" alignItems="center" justifyContent="center">
+                    <Settings size={15} color="#475569" />
+                  </Box>
+                  <Box minW={0}>
+                    <Text fontSize="14px" fontWeight="650" color="gray.900">{t('settings.appInformation', 'Application')}</Text>
+                    <Text fontSize="12px" color="gray.500" lineHeight="1.4">{t('settings.appDescription')}</Text>
+                  </Box>
+                </HStack>
+                <Text px={2.5} py={1} flexShrink={0} borderRadius="full" bg="gray.100" color="gray.600" fontSize="10px" fontWeight="700">
+                  {t('settings.version')}
+                </Text>
+              </HStack>
 
-              {/* Support Links */}
-              <Grid templateColumns="1fr 1fr" gap={3}>
+              {/* Legal links */}
+              <HStack justify="space-between" align="center" gap={4} minH="68px" px={{ base: 4, md: 5 }} py={3} borderTop="1px solid" borderColor="gray.100">
+                <HStack gap={3} minW={0}>
+                  <Box w="36px" h="36px" flexShrink={0} borderRadius="10px" bg="green.50" border="1px solid" borderColor="green.100" display="flex" alignItems="center" justifyContent="center">
+                    <ShieldCheck size={15} color="#059669" />
+                  </Box>
+                  <Text fontSize="13px" fontWeight="600" color="gray.800">{t('settings.privacyPolicy')}</Text>
+                </HStack>
                 <Button
-                  bg="green.500"
-                  color="white"
-                  borderRadius="12px"
-                  p={4}
-                  h="auto"
+                  size="sm"
+                  variant="ghost"
+                  h="32px"
+                  borderRadius="8px"
+                  color="gray.600"
+                  fontSize="12px"
+                  fontWeight="650"
                   onClick={() => setShowPrivacyPolicyModal(true)}
-                  _hover={{ bg: 'green.600', transform: 'translateY(-1px)' }}
-                  _active={{ transform: 'translateY(0)' }}
-                  transition="all 0.2s"
+                  _hover={{ bg: 'gray.100', color: 'gray.900' }}
                 >
-                  <VStack gap={2}>
-                    <ShieldCheck size={20} />
-                    <Text fontSize="12px" fontWeight="600">{t('settings.privacyPolicy')}</Text>
-                  </VStack>
+                  {t('settings.viewAction', 'View')}
                 </Button>
+              </HStack>
 
+              <HStack justify="space-between" align="center" gap={4} minH="68px" px={{ base: 4, md: 5 }} py={3} borderTop="1px solid" borderColor="gray.100">
+                <HStack gap={3} minW={0}>
+                  <Box w="36px" h="36px" flexShrink={0} borderRadius="10px" bg="orange.50" border="1px solid" borderColor="orange.100" display="flex" alignItems="center" justifyContent="center">
+                    <FileText size={15} color="#d97706" />
+                  </Box>
+                  <Text fontSize="13px" fontWeight="600" color="gray.800">{t('settings.termsOfService')}</Text>
+                </HStack>
                 <Button
-                  bg="orange.500"
-                  color="white"
-                  borderRadius="12px"
-                  p={4}
-                  h="auto"
+                  size="sm"
+                  variant="ghost"
+                  h="32px"
+                  borderRadius="8px"
+                  color="gray.600"
+                  fontSize="12px"
+                  fontWeight="650"
                   onClick={() => setShowTermsOfServiceModal(true)}
-                  _hover={{ bg: 'orange.600', transform: 'translateY(-1px)' }}
-                  _active={{ transform: 'translateY(0)' }}
-                  transition="all 0.2s"
+                  _hover={{ bg: 'gray.100', color: 'gray.900' }}
                 >
-                  <VStack gap={2}>
-                    <FileText size={20} />
-                    <Text fontSize="12px" fontWeight="600">{t('settings.termsOfService')}</Text>
-                  </VStack>
+                  {t('settings.viewAction', 'View')}
                 </Button>
-              </Grid>
+              </HStack>
             </VStack>
           </Box>
 
           {/* Logout Section */}
-          <Box bg="white" borderRadius="16px" p={5} border="1px solid" borderColor="gray.200" boxShadow="0 2px 8px rgba(0, 0, 0, 0.04)">
+          <Box bg="white" borderRadius="16px" px={{ base: 4, md: 5 }} py={4} border="1px solid" borderColor="gray.200" boxShadow="0 2px 8px rgba(0, 0, 0, 0.04)">
+            <HStack justify="space-between" align="center" gap={4}>
+              <Box minW={0}>
+                <Text fontSize="13px" fontWeight="650" color="gray.800">{t('settings.sessionTitle', 'Current session')}</Text>
+                <Text mt={0.5} fontSize="11px" color="gray.500" overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
+                  {user?.email || t('settings.signedIn', 'Signed in')}
+                </Text>
+              </Box>
             <Button
-              bg="red.500"
-              color="white"
-              borderRadius="12px"
-              px={6}
-              py={4}
-              fontSize="18px"
-              fontWeight="700"
+              size="sm"
+              variant="outline"
+              h="34px"
+              flexShrink={0}
+              borderRadius="9px"
+              borderColor="gray.300"
+              bg="white"
+              color="gray.700"
+              px={3}
+              fontSize="12px"
+              fontWeight="650"
               onClick={handleLogout}
-              w="full"
-              _hover={{ bg: 'red.600', transform: 'translateY(-1px)' }}
-              _active={{ transform: 'translateY(0)' }}
-              transition="all 0.2s"
+              _hover={{ bg: 'gray.50', borderColor: 'gray.400', color: 'gray.900' }}
+              _active={{ bg: 'gray.100' }}
             >
-              <HStack gap={3} justify="center">
-                <LogOut size={20} />
+              <HStack gap={2} justify="center">
+                <LogOut size={14} />
                 <Text>{t('settings.logoutButton')}</Text>
               </HStack>
             </Button>
+            </HStack>
           </Box>
         </VStack>
       </Box>
@@ -506,94 +616,92 @@ const SettingsView: React.FC = () => {
           left={0}
           right={0}
           bottom={0}
-          bg="rgba(0, 0, 0, 0.5)"
+          bg="rgba(15, 23, 42, 0.62)"
+          backdropFilter="blur(7px)"
           display="flex"
           alignItems="center"
           justifyContent="center"
-          zIndex={2000}
+          zIndex="var(--app-z-modal)"
           p={4}
         >
           <Box
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="change-password-title"
             bg="white"
-            borderRadius="16px"
-            p={6}
+            borderRadius="20px"
+            p={{ base: 5, md: 6 }}
             maxW="420px"
             w="full"
-            boxShadow="0 20px 25px rgba(0, 0, 0, 0.1)"
+            border="1px solid"
+            borderColor="gray.200"
+            boxShadow="0 28px 80px rgba(15, 23, 42, 0.28)"
           >
-            <VStack gap={6} align="stretch">
+            <VStack gap={5} align="stretch">
               <HStack justify="space-between" align="center">
                 <HStack gap={3}>
-                  <Box w="10" h="10" borderRadius="8px" bg="blue.100" display="flex" alignItems="center" justifyContent="center">
-                    <Key size={16} color="#2563eb" />
+                  <Box w="36px" h="36px" borderRadius="10px" bg="blue.50" border="1px solid" borderColor="blue.100" display="flex" alignItems="center" justifyContent="center">
+                    <Key size={15} color="#2563eb" />
                   </Box>
-                  <Text fontSize="20px" fontWeight="700">{t('settings.modals.changePassword.title')}</Text>
+                  <Text id="change-password-title" fontSize="17px" fontWeight="700" letterSpacing="-0.2px">{t('settings.modals.changePassword.title')}</Text>
                 </HStack>
                 <Button
                   size="sm"
                   variant="ghost"
-                  borderRadius="full"
-                  p={2}
-                  minW="auto"
-                  h="auto"
+                  aria-label={t('settings.modals.changePassword.cancel')}
+                  borderRadius="9px"
+                  p={0}
+                  minW="32px"
+                  w="32px"
+                  h="32px"
+                  color="gray.500"
+                  _hover={{ bg: 'gray.100', color: 'gray.900' }}
                   onClick={() => {
                     setShowPasswordModal(false);
                     setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
                   }}
                 >
-                  ✕
+                  <X size={15} />
                 </Button>
               </HStack>
 
-              <VStack gap={4} align="stretch">
+              <VStack gap={3.5} align="stretch">
                 <Box>
-                  <Text fontSize="14px" fontWeight="600" mb={2}>{t('settings.modals.changePassword.currentPassword')}</Text>
+                  <Text fontSize="12px" color="gray.700" fontWeight="650" mb={1.5}>{t('settings.modals.changePassword.currentPassword')}</Text>
                   <input
+                    className="settings-password-input"
                     type="password"
+                    autoComplete="current-password"
+                    aria-label={t('settings.modals.changePassword.currentPassword')}
                     value={passwordForm.currentPassword}
                     onChange={(e) => setPasswordForm(prev => ({ ...prev, currentPassword: e.target.value }))}
                     placeholder={t('settings.modals.changePassword.currentPlaceholder')}
-                    style={{
-                      width: '100%',
-                      padding: '12px',
-                      border: '1px solid #d1d5db',
-                      borderRadius: '8px',
-                      fontSize: '16px',
-                    }}
                   />
                 </Box>
 
                 <Box>
-                  <Text fontSize="14px" fontWeight="600" mb={2}>{t('settings.modals.changePassword.newPassword')}</Text>
+                  <Text fontSize="12px" color="gray.700" fontWeight="650" mb={1.5}>{t('settings.modals.changePassword.newPassword')}</Text>
                   <input
+                    className="settings-password-input"
                     type="password"
+                    autoComplete="new-password"
+                    aria-label={t('settings.modals.changePassword.newPassword')}
                     value={passwordForm.newPassword}
                     onChange={(e) => setPasswordForm(prev => ({ ...prev, newPassword: e.target.value }))}
                     placeholder={t('settings.modals.changePassword.newPlaceholder')}
-                    style={{
-                      width: '100%',
-                      padding: '12px',
-                      border: '1px solid #d1d5db',
-                      borderRadius: '8px',
-                      fontSize: '16px',
-                    }}
                   />
                 </Box>
 
                 <Box>
-                  <Text fontSize="14px" fontWeight="600" mb={2}>{t('settings.modals.changePassword.confirmNewPassword')}</Text>
+                  <Text fontSize="12px" color="gray.700" fontWeight="650" mb={1.5}>{t('settings.modals.changePassword.confirmNewPassword')}</Text>
                   <input
+                    className="settings-password-input"
                     type="password"
+                    autoComplete="new-password"
+                    aria-label={t('settings.modals.changePassword.confirmNewPassword')}
                     value={passwordForm.confirmPassword}
                     onChange={(e) => setPasswordForm(prev => ({ ...prev, confirmPassword: e.target.value }))}
                     placeholder={t('settings.modals.changePassword.confirmPlaceholder')}
-                    style={{
-                      width: '100%',
-                      padding: '12px',
-                      border: '1px solid #d1d5db',
-                      borderRadius: '8px',
-                      fontSize: '16px',
-                    }}
                   />
                 </Box>
               </VStack>
@@ -602,8 +710,9 @@ const SettingsView: React.FC = () => {
                 <Button
                   flex={1}
                   variant="outline"
-                  borderRadius="8px"
-                  py={3}
+                  h="36px"
+                  borderRadius="9px"
+                  fontSize="12px"
                   onClick={() => {
                     setShowPasswordModal(false);
                     setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
@@ -613,13 +722,14 @@ const SettingsView: React.FC = () => {
                 </Button>
                 <Button
                   flex={1}
-                  bg="blue.500"
+                  h="36px"
+                  bg="#111318"
                   color="white"
-                  borderRadius="8px"
-                  py={3}
+                  borderRadius="9px"
+                  fontSize="12px"
                   onClick={handlePasswordChange}
                   disabled={loading}
-                  _hover={{ bg: 'blue.600' }}
+                  _hover={{ bg: '#252830' }}
                 >
                   {loading ? t('settings.modals.changePassword.changing') : t('settings.modals.changePassword.submit')}
                 </Button>
@@ -637,49 +747,76 @@ const SettingsView: React.FC = () => {
           left={0}
           right={0}
           bottom={0}
-          bg="rgba(0, 0, 0, 0.5)"
+          bg="rgba(15, 23, 42, 0.62)"
+          backdropFilter="blur(7px)"
           display="flex"
           alignItems="center"
           justifyContent="center"
-          zIndex={2000}
+          zIndex="var(--app-z-modal)"
           p={4}
         >
           <Box
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="delete-account-title"
             bg="white"
-            borderRadius="16px"
-            p={6}
+            borderRadius="20px"
+            p={{ base: 5, md: 6 }}
             maxW="400px"
             w="full"
-            boxShadow="0 20px 25px rgba(0, 0, 0, 0.1)"
+            border="1px solid"
+            borderColor="red.100"
+            boxShadow="0 28px 80px rgba(15, 23, 42, 0.28)"
           >
-            <VStack gap={4} align="stretch">
-              <Text fontSize="20px" fontWeight="700" color="red.600">⚠️ Delete Account</Text>
+            <VStack gap={5} align="stretch">
+              <HStack gap={3} align="flex-start">
+                <Box w="36px" h="36px" flexShrink={0} borderRadius="10px" bg="red.50" border="1px solid" borderColor="red.100" display="flex" alignItems="center" justifyContent="center">
+                  <AlertTriangle size={16} color="#dc2626" />
+                </Box>
+                <Box>
+                  <Text id="delete-account-title" fontSize="17px" fontWeight="700" color="gray.900" letterSpacing="-0.2px">
+                    {t('settings.deleteAccountTitle', 'Delete account')}
+                  </Text>
+                  <Text mt={1} fontSize="12px" color="red.600" fontWeight="600">
+                    {t('settings.permanentAction', 'Permanent action')}
+                  </Text>
+                </Box>
+              </HStack>
 
-              <Text fontSize="14px" color="gray.700" lineHeight="1.5">
-                This action cannot be undone. All your reports, votes, profile data, and account information will be permanently deleted.
-              </Text>
+              <Box px={4} py={3.5} borderRadius="12px" bg="red.50" border="1px solid" borderColor="red.100">
+                <Text fontSize="13px" color="gray.700" lineHeight="1.55">
+                  {t('settings.deleteAccountWarning', 'This cannot be undone. Your reports, votes, profile, and account information will be permanently deleted.')}
+                </Text>
+                {user?.email && (
+                  <Text mt={2} fontSize="11px" color="gray.500" fontWeight="600" overflowWrap="anywhere">
+                    {user.email}
+                  </Text>
+                )}
+              </Box>
 
               <HStack gap={3}>
                 <Button
                   flex={1}
                   variant="outline"
-                  borderRadius="8px"
-                  py={3}
+                  h="36px"
+                  borderRadius="9px"
+                  fontSize="12px"
                   onClick={() => setShowDeleteModal(false)}
                 >
-                  Cancel
+                  {t('settings.modals.changePassword.cancel', 'Cancel')}
                 </Button>
                 <Button
                   flex={1}
-                  bg="red.500"
+                  h="36px"
+                  bg="red.600"
                   color="white"
-                  borderRadius="8px"
-                  py={3}
+                  borderRadius="9px"
+                  fontSize="12px"
                   onClick={handleDeleteAccount}
                   disabled={loading}
-                  _hover={{ bg: 'red.600' }}
+                  _hover={{ bg: 'red.700' }}
                 >
-                  {loading ? 'Deleting...' : 'Delete Account'}
+                  {loading ? t('settings.deleting', 'Deleting…') : t('settings.deleteAccountButton', 'Delete account')}
                 </Button>
               </HStack>
             </VStack>
@@ -707,78 +844,88 @@ const SettingsView: React.FC = () => {
           left={0}
           right={0}
           bottom={0}
-          bg="rgba(0, 0, 0, 0.5)"
+          bg="rgba(15, 23, 42, 0.62)"
+          backdropFilter="blur(7px)"
           display="flex"
           alignItems="center"
           justifyContent="center"
-          zIndex={2000}
+          zIndex="var(--app-z-modal)"
           p={4}
         >
           <Box
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="location-sharing-title"
             bg="white"
-            borderRadius="16px"
-            p={6}
+            borderRadius="20px"
+            p={{ base: 5, md: 6 }}
             maxW="450px"
             w="full"
-            boxShadow="0 20px 25px rgba(0, 0, 0, 0.1)"
+            border="1px solid"
+            borderColor="gray.200"
+            boxShadow="0 28px 80px rgba(15, 23, 42, 0.28)"
           >
-            <VStack gap={6} align="stretch">
+            <VStack gap={5} align="stretch">
               <HStack justify="space-between" align="center">
                 <HStack gap={3}>
-                  <Box w="10" h="10" borderRadius="8px" bg="green.100" display="flex" alignItems="center" justifyContent="center">
-                    <MapPin size={16} color="#059669" />
+                  <Box w="36px" h="36px" borderRadius="10px" bg="green.50" border="1px solid" borderColor="green.100" display="flex" alignItems="center" justifyContent="center">
+                    <MapPin size={15} color="#059669" />
                   </Box>
-                  <Text fontSize="20px" fontWeight="700">Location Sharing Agreement</Text>
+                  <Text id="location-sharing-title" fontSize="17px" fontWeight="700" letterSpacing="-0.2px">Location sharing</Text>
                 </HStack>
                 <Button
                   size="sm"
                   variant="ghost"
-                  borderRadius="full"
-                  p={2}
-                  minW="auto"
-                  h="auto"
+                  aria-label="Close location sharing agreement"
+                  borderRadius="9px"
+                  p={0}
+                  minW="32px"
+                  w="32px"
+                  h="32px"
+                  color="gray.500"
+                  _hover={{ bg: 'gray.100', color: 'gray.900' }}
                   onClick={() => setShowLocationSharingAgreement(false)}
                 >
-                  ✕
+                  <X size={15} />
                 </Button>
               </HStack>
 
-              <VStack gap={4} align="stretch">
-                <Text fontSize="16px" fontWeight="600" color="gray.900">
-                  By enabling location sharing, you agree to:
+              <VStack gap={3.5} align="stretch">
+                <Text fontSize="13px" fontWeight="600" color="gray.800">
+                  Enabling this setting allows HyperApp to:
                 </Text>
 
-                <VStack gap={3} align="start">
+                <VStack gap={2.5} align="start">
                   <HStack gap={3} align="start">
-                    <Box w="6" h="6" borderRadius="full" bg="green.500" display="flex" alignItems="center" justifyContent="center" mt={0.5} flexShrink={0}>
-                      <Text fontSize="12px" color="white" fontWeight="bold">✓</Text>
+                    <Box w="20px" h="20px" borderRadius="full" bg="green.50" border="1px solid" borderColor="green.200" display="flex" alignItems="center" justifyContent="center" mt={0.5} flexShrink={0}>
+                      <Text fontSize="10px" color="green.700" fontWeight="bold">✓</Text>
                     </Box>
-                    <Text fontSize="14px" color="gray.700">
+                    <Text fontSize="12px" color="gray.600" lineHeight="1.5">
                       Share your location with other community members on the map
                     </Text>
                   </HStack>
 
                   <HStack gap={3} align="start">
-                    <Box w="6" h="6" borderRadius="full" bg="green.500" display="flex" alignItems="center" justifyContent="center" mt={0.5} flexShrink={0}>
-                      <Text fontSize="12px" color="white" fontWeight="bold">✓</Text>
+                    <Box w="20px" h="20px" borderRadius="full" bg="green.50" border="1px solid" borderColor="green.200" display="flex" alignItems="center" justifyContent="center" mt={0.5} flexShrink={0}>
+                      <Text fontSize="10px" color="green.700" fontWeight="bold">✓</Text>
                     </Box>
-                    <Text fontSize="14px" color="gray.700">
+                    <Text fontSize="12px" color="gray.600" lineHeight="1.5">
                       Allow other users to see you as a nearby community member
                     </Text>
                   </HStack>
 
                   <HStack gap={3} align="start">
-                    <Box w="6" h="6" borderRadius="full" bg="green.500" display="flex" alignItems="center" justifyContent="center" mt={0.5} flexShrink={0}>
-                      <Text fontSize="12px" color="white" fontWeight="bold">✓</Text>
+                    <Box w="20px" h="20px" borderRadius="full" bg="green.50" border="1px solid" borderColor="green.200" display="flex" alignItems="center" justifyContent="center" mt={0.5} flexShrink={0}>
+                      <Text fontSize="10px" color="green.700" fontWeight="bold">✓</Text>
                     </Box>
-                    <Text fontSize="14px" color="gray.700">
+                    <Text fontSize="12px" color="gray.600" lineHeight="1.5">
                       Help build a safer community by connecting with nearby users
                     </Text>
                   </HStack>
                 </VStack>
 
-                <Box p={4} bg="gray.50" borderRadius="8px">
-                  <Text fontSize="13px" color="gray.600" lineHeight="1.5">
+                <Box p={3.5} bg="gray.50" border="1px solid" borderColor="gray.200" borderRadius="11px">
+                  <Text fontSize="11px" color="gray.600" lineHeight="1.55">
                     <strong>Privacy Note:</strong> Your location data is used only for community safety features and is not shared with third parties. You can disable this at any time.
                   </Text>
                 </Box>
@@ -788,22 +935,24 @@ const SettingsView: React.FC = () => {
                 <Button
                   flex={1}
                   variant="outline"
-                  borderRadius="8px"
-                  py={3}
+                  h="36px"
+                  borderRadius="9px"
+                  fontSize="12px"
                   onClick={() => setShowLocationSharingAgreement(false)}
                 >
                   Cancel
                 </Button>
                 <Button
                   flex={1}
-                  bg="green.500"
+                  h="36px"
+                  bg="#111318"
                   color="white"
-                  borderRadius="8px"
-                  py={3}
+                  borderRadius="9px"
+                  fontSize="12px"
                   onClick={confirmLocationSharing}
-                  _hover={{ bg: 'green.600' }}
+                  _hover={{ bg: '#252830' }}
                 >
-                  I Agree - Enable Sharing
+                  Enable sharing
                 </Button>
               </HStack>
             </VStack>

--- a/src/components/TabNavigation.test.tsx
+++ b/src/components/TabNavigation.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TabNavigation from './TabNavigation';
+
+const i18nMock = vi.hoisted(() => ({
+  language: 'en',
+  on: vi.fn(),
+  off: vi.fn(),
+}));
+
+vi.mock('../i18n', () => ({ default: i18nMock }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key.split('.').at(-1),
+  }),
+}));
+
+describe('TabNavigation More menu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens from the More button and exposes Profile and Settings', () => {
+    render(
+      <TabNavigation
+        activeTab="dashboard"
+        onTabChange={vi.fn()}
+        onNewReport={vi.fn()}
+      />,
+    );
+
+    const moreButton = screen.getByRole('button', { name: 'More' });
+    expect(moreButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(moreButton);
+
+    expect(moreButton).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('menu', { name: 'More' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'profile' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'settings' })).toBeInTheDocument();
+  });
+
+  it('selects a menu destination and closes the menu', () => {
+    const onTabChange = vi.fn();
+    render(
+      <TabNavigation
+        activeTab="dashboard"
+        onTabChange={onTabChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'profile' }));
+
+    expect(onTabChange).toHaveBeenCalledWith('profile');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -1,18 +1,11 @@
-import React, { useRef, useEffect, useState } from 'react';
+/* eslint-disable no-unused-vars -- the legacy base rule misreads TypeScript callback signatures */
+import React, { useEffect, useRef, useState } from 'react';
+import { LayoutDashboard, Map, Menu, Plus, Settings, User, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import {
-  Map,
-  Users,
-  User,
-  Settings,
-  Plus,
-  Shield,
-  Activity,
-} from 'lucide-react';
 
 import i18n from '../i18n';
 
-export type TabType = 'map' | 'reports' | 'hub' | 'guardian' | 'profile' | 'settings';
+export type TabType = 'dashboard' | 'map' | 'reports' | 'profile' | 'settings';
 
 interface TabNavigationProps {
   activeTab: TabType;
@@ -23,158 +16,108 @@ interface TabNavigationProps {
 const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onTabChange, onNewReport }) => {
   const { t } = useTranslation();
   const [currentLanguage, setCurrentLanguage] = useState(i18n.language);
+  const [isMoreOpen, setIsMoreOpen] = useState(false);
+  const navigationRef = useRef<React.ElementRef<'nav'>>(null);
 
   const tabs = [
-    {
-      id: 'map' as TabType,
-      label: t('tabs.map'),
-      icon: Map,
-      ariaLabel: t('tabs.map'),
-    },
-    {
-      id: 'reports' as TabType,
-      label: t('tabs.community'),
-      icon: Users,
-      ariaLabel: t('tabs.community'),
-    },
-    {
-      id: 'hub' as TabType,
-      label: t('tabs.hub', 'Hub'),
-      icon: Activity,
-      ariaLabel: t('tabs.hub', 'Hub'),
-    },
-    {
-      id: 'guardian' as TabType,
-      label: t('tabs.guardian', 'Guardian'),
-      icon: Shield,
-      ariaLabel: t('tabs.guardian', 'Guardian'),
-    },
-    {
-      id: 'profile' as TabType,
-      label: t('tabs.profile'),
-      icon: User,
-      ariaLabel: t('tabs.profile'),
-    },
-    {
-      id: 'settings' as TabType,
-      label: t('tabs.settings'),
-      icon: Settings,
-      ariaLabel: t('tabs.settings'),
-    },
+    { id: 'dashboard' as TabType, label: t('tabs.dashboard', 'Overview'), icon: LayoutDashboard },
+    { id: 'map' as TabType, label: t('tabs.map'), icon: Map },
+    { id: 'reports' as TabType, label: t('tabs.community'), icon: Users },
   ];
 
-  useEffect(() => {
-    const handleLanguageChange = (lng: string) => {
-      setCurrentLanguage(lng);
-    };
+  const moreTabs = [
+    { id: 'profile' as TabType, label: t('tabs.profile'), icon: User },
+    { id: 'settings' as TabType, label: t('tabs.settings'), icon: Settings },
+  ];
 
+  const isMoreActive = moreTabs.some((tab) => tab.id === activeTab);
+
+  useEffect(() => {
+    const handleLanguageChange = (language: string) => setCurrentLanguage(language);
     i18n.on('languageChanged', handleLanguageChange);
-    return () => {
-      i18n.off('languageChanged', handleLanguageChange);
-    };
+    return () => i18n.off('languageChanged', handleLanguageChange);
   }, []);
 
-  return (
-    <>
-      <nav
-        style={{
-          display: 'flex',
-          position: 'fixed',
-          bottom: 0,
-          left: 0,
-          right: 0,
-          background: 'rgba(9,9,11,0.96)',
-          borderTop: '0.5px solid rgba(255,255,255,0.07)',
-          backdropFilter: 'blur(20px)',
-          WebkitBackdropFilter: 'blur(20px)',
-          alignItems: 'center',
-          padding: '6px 4px',
-          paddingBottom: 'calc(6px + env(safe-area-inset-bottom, 0px))',
-          zIndex: 90,
-          height: '72px',
-        }}
-        aria-label="Main navigation"
-      >
-        {tabs.map((tab, index) => {
-          const isActive = activeTab === tab.id;
-          return (
-            <React.Fragment key={`${tab.id}-${currentLanguage}`}>
-              <button
-                data-tab={tab.id}
-                onClick={() => onTabChange(tab.id)}
-                style={{
-                  flex: 1,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '3px',
-                  padding: '4px 0',
-                  border: 'none',
-                  background: 'transparent',
-                  cursor: 'pointer',
-                  minHeight: '52px',
-                  WebkitTapHighlightColor: 'transparent',
-                }}
-              >
-                <div style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}>
-                  <tab.icon
-                    size={20}
-                    color={isActive ? 'var(--accent)' : 'var(--t3)'}
-                    strokeWidth={isActive ? 2.5 : 1.8}
-                  />
-                </div>
-                <span style={{
-                  fontSize: '10px',
-                  fontWeight: isActive ? '600' : '400',
-                  color: isActive ? 'var(--accent)' : 'var(--t3)',
-                  lineHeight: 1,
-                }}>
-                  {tab.label}
-                </span>
-                {isActive && (
-                  <div style={{
-                    width: '3px',
-                    height: '3px',
-                    borderRadius: '50%',
-                    background: 'var(--accent)',
-                  }} />
-                )}
-              </button>
+  useEffect(() => {
+    if (!isMoreOpen) {
+      return undefined;
+    }
 
-              {index === 2 && onNewReport && (
-                <button
-                  onClick={onNewReport}
-                  style={{
-                    width: '42px',
-                    height: '42px',
-                    flexShrink: 0,
-                    borderRadius: '12px',
-                    background: 'var(--accent)',
-                    border: 'none',
-                    color: 'var(--accent-text)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    cursor: 'pointer',
-                    marginBottom: '4px',
-                    marginTop: '2px',
-                    boxShadow: '0 4px 16px rgba(0,200,150,0.35)',
-                    WebkitTapHighlightColor: 'transparent',
-                  }}
-                >
-                  <Plus size={20} />
-                </button>
-              )}
-            </React.Fragment>
-          );
-        })}
-      </nav>
-    </>
+    const closeMoreMenu = (event: globalThis.PointerEvent) => {
+      if (!navigationRef.current?.contains(event.target as globalThis.Node)) {
+        setIsMoreOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', closeMoreMenu);
+    return () => document.removeEventListener('pointerdown', closeMoreMenu);
+  }, [isMoreOpen]);
+
+  const selectTab = (tab: TabType) => {
+    onTabChange(tab);
+    setIsMoreOpen(false);
+  };
+
+  return (
+    <nav ref={navigationRef} className="tab-navigation" aria-label={t('app.mainNavigation', 'Main navigation')}>
+      {isMoreOpen && (
+        <div className="tab-more-menu" role="menu" aria-label={t('tabs.more', 'More')}>
+          {moreTabs.map(({ id, label, icon: Icon }) => (
+            <button
+              key={id}
+              type="button"
+              role="menuitem"
+              className={activeTab === id ? 'tab-more-menu__item is-active' : 'tab-more-menu__item'}
+              onClick={() => selectTab(id)}
+            >
+              <Icon size={18} aria-hidden="true" />
+              <span>{label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {tabs.map((tab, index) => {
+        const isActive = activeTab === tab.id;
+        return (
+          <React.Fragment key={`${tab.id}-${currentLanguage}`}>
+            <button
+              type="button"
+              data-tab={tab.id}
+              className={isActive ? 'tab-navigation__item is-active' : 'tab-navigation__item'}
+              aria-current={isActive ? 'page' : undefined}
+              onClick={() => selectTab(tab.id)}
+            >
+              <span className="tab-navigation__icon"><tab.icon size={19} /></span>
+              <span>{tab.label}</span>
+            </button>
+
+            {index === 1 && onNewReport && (
+              <button
+                type="button"
+                className="tab-navigation__create"
+                onClick={onNewReport}
+                aria-label={t('app.newReport', 'New report')}
+              >
+                <Plus size={20} />
+              </button>
+            )}
+          </React.Fragment>
+        );
+      })}
+
+      <button
+        type="button"
+        className={isMoreActive || isMoreOpen ? 'tab-more-toggle is-active' : 'tab-more-toggle'}
+        aria-expanded={isMoreOpen}
+        aria-haspopup="menu"
+        aria-label={t('tabs.more', 'More')}
+        onClick={() => setIsMoreOpen((open) => !open)}
+      >
+        <span className="tab-more-toggle__icon"><Menu size={19} aria-hidden="true" /></span>
+        <span>{t('tabs.more', 'More')}</span>
+      </button>
+    </nav>
   );
 };
 

--- a/src/components/VibeLegend.tsx
+++ b/src/components/VibeLegend.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ChevronUp, ChevronDown } from 'lucide-react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
 import { VIBE_CONFIG } from '../constants/vibes';
 
@@ -9,72 +9,69 @@ const VibeLegend: React.FC = () => {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const toggleExpanded = () => {
-    setIsExpanded(!isExpanded);
-  };
-
   return (
     <div
+      className="vibe-legend"
       style={{
         position: 'absolute',
-        bottom: '20px',
-        right: '10px',
-        zIndex: 1000,
-        background: 'var(--bg-surface)',
-        backdropFilter: 'blur(10px)',
-        borderRadius: '12px',
-        border: '0.5px solid var(--wire)',
-        boxShadow: '0 4px 12px rgba(0,200,150,0.1)',
-        overflow: 'hidden',
-        minWidth: '140px',
+        right: '18px',
+        bottom: '18px',
+        zIndex: 40,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-end',
+        gap: '10px',
+        pointerEvents: 'none',
       }}
     >
-      {/* Header */}
-      <button
-        onClick={toggleExpanded}
-        style={{
-          width: '100%',
-          padding: '8px 12px',
-          background: 'none',
-          border: 'none',
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          fontSize: '12px',
-          fontWeight: '600',
-          color: 'var(--t1)',
-          WebkitTapHighlightColor: 'transparent',
-        }}
-        aria-label={isExpanded ? t('community.vibeLegendCollapse') : t('community.vibeLegendExpand')}
-      >
-        <span>{t('community.vibeLegend')}</span>
-        {isExpanded ? (
-          <ChevronDown size={14} color="var(--t2)" />
-        ) : (
-          <ChevronUp size={14} color="var(--t2)" />
-        )}
-      </button>
-
-      {/* Expandable Content */}
       <AnimatePresence>
         {isExpanded && (
           <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            initial={{ opacity: 0, y: 8, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.96 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
             style={{
+              width: '240px',
+              maxHeight: '300px',
               overflow: 'hidden',
+              background: 'rgba(255,255,255,0.98)',
+              backdropFilter: 'blur(16px)',
+              borderRadius: '16px',
+              border: '1px solid rgba(15, 23, 42, 0.08)',
+              boxShadow: '0 16px 32px rgba(15, 23, 42, 0.10)',
+              pointerEvents: 'auto',
             }}
           >
+            <button
+              onClick={() => setIsExpanded(false)}
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                fontSize: '12px',
+                fontWeight: '700',
+                color: '#0f172a',
+                WebkitTapHighlightColor: 'transparent',
+              }}
+              aria-label={t('community.vibeLegendCollapse')}
+            >
+              <span>{t('community.vibeLegend')}</span>
+              <ChevronDown size={15} color="#0f172a" />
+            </button>
+
             <div
               style={{
-                padding: '8px',
-                display: 'grid',
-                gridTemplateColumns: 'repeat(2, 1fr)',
-                gap: '6px',
-                maxHeight: '200px',
+                padding: '0 12px 12px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '8px',
+                maxHeight: '240px',
                 overflowY: 'auto',
               }}
             >
@@ -84,31 +81,29 @@ const VibeLegend: React.FC = () => {
                   style={{
                     display: 'flex',
                     alignItems: 'center',
-                    gap: '6px',
-                    padding: '4px 6px',
-                    borderRadius: '6px',
-                    background: 'var(--bg-elevated)',
+                    gap: '8px',
+                    padding: '7px 8px',
+                    borderRadius: '10px',
+                    background: 'rgba(15, 23, 42, 0.04)',
                     fontSize: '11px',
-                    fontWeight: '500',
-                    color: 'var(--t1)',
+                    fontWeight: '600',
+                    color: '#0f172a',
                     whiteSpace: 'nowrap',
                   }}
                 >
-                  {/* Color indicator */}
                   <div
                     style={{
                       width: '12px',
                       height: '12px',
                       borderRadius: '50%',
                       backgroundColor: config.color,
-                      border: '0.5px solid rgba(255,255,255,0.1)',
+                      border: '1px solid rgba(15, 23, 42, 0.08)',
                       flexShrink: 0,
                     }}
                   />
-                  {/* Icon and label */}
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0 }}>
                     <span style={{ fontSize: '10px' }}>{config.icon}</span>
-                    <span style={{ fontSize: '10px', fontWeight: '600' }}>
+                    <span style={{ fontSize: '10px', fontWeight: '700', color: '#0f172a', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                       {t(`vibes.${vibeType}`, config.label)}
                     </span>
                   </div>
@@ -118,6 +113,29 @@ const VibeLegend: React.FC = () => {
           </motion.div>
         )}
       </AnimatePresence>
+
+      <button
+        onClick={() => setIsExpanded(prev => !prev)}
+        style={{
+          pointerEvents: 'auto',
+          width: '52px',
+          height: '52px',
+          borderRadius: '18px',
+          border: '1px solid rgba(15, 23, 42, 0.08)',
+          background: 'rgba(255,255,255,0.98)',
+          backdropFilter: 'blur(16px)',
+          boxShadow: '0 12px 26px rgba(15, 23, 42, 0.10)',
+          color: '#0f172a',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          WebkitTapHighlightColor: 'transparent',
+        }}
+        aria-label={isExpanded ? t('community.vibeLegendCollapse') : t('community.vibeLegendExpand')}
+      >
+        {isExpanded ? <ChevronDown size={18} color="#0f172a" /> : <ChevronUp size={18} color="#0f172a" />}
+      </button>
     </div>
   );
 };

--- a/src/components/VoiceChatModal.test.tsx
+++ b/src/components/VoiceChatModal.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -87,9 +88,9 @@ describe('VoiceChatModal hands-free conversation', () => {
       recognition?.onresult?.({ results: [[{ transcript: 'What changed nearby?' }]] });
     });
 
-    expect(await screen.findByText('Thinking...')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'End conversation' })).toBeTruthy();
-    expect(screen.getByRole('textbox', { name: 'Message Hyper AI' })).toBeTruthy();
+    expect(await screen.findByText('Thinking...')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'End conversation' })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'Message Hyper AI' })).toBeVisible();
 
     await act(async () => {
       resolveAnswer?.({ answer: 'There are no verified changes nearby.' });
@@ -97,6 +98,6 @@ describe('VoiceChatModal hands-free conversation', () => {
 
     await waitFor(() => expect(mocks.speak).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(recognition?.start).toHaveBeenCalledTimes(2), { timeout: 2000 });
-    expect(screen.getByRole('button', { name: 'End conversation' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'End conversation' })).toBeVisible();
   });
 });

--- a/src/components/shared/Input.tsx
+++ b/src/components/shared/Input.tsx
@@ -19,11 +19,10 @@ export const Input: React.FC<InputProps> = ({
   const baseClasses = 'px-3 py-2 border rounded-lg text-sm focus:outline-none transition-all duration-200';
   const errorClasses = error ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-blue-500';
   const widthClass = fullWidth ? 'w-full' : '';
-  const darkClasses = 'dark:bg-gray-800 dark:border-gray-600 dark:text-white dark:focus:border-blue-400';
 
   return (
     <input
-      className={`${baseClasses} ${errorClasses} ${widthClass} ${darkClasses} ${className}`}
+      className={`${baseClasses} ${errorClasses} ${widthClass} ${className}`}
       {...props}
     />
   );
@@ -38,11 +37,10 @@ export const Textarea: React.FC<TextareaProps> = ({
   const baseClasses = 'px-3 py-2 border rounded-lg text-sm focus:outline-none transition-all duration-200 resize-vertical';
   const errorClasses = error ? 'border-red-500 focus:border-red-500' : 'border-gray-300 focus:border-blue-500';
   const widthClass = fullWidth ? 'w-full' : '';
-  const darkClasses = 'dark:bg-gray-800 dark:border-gray-600 dark:text-white dark:focus:border-blue-400';
 
   return (
     <textarea
-      className={`${baseClasses} ${errorClasses} ${widthClass} ${darkClasses} ${className}`}
+      className={`${baseClasses} ${errorClasses} ${widthClass} ${className}`}
       {...props}
     />
   );

--- a/src/components/shared/NotificationBell.tsx
+++ b/src/components/shared/NotificationBell.tsx
@@ -1,39 +1,97 @@
-import React, { useState, useEffect, useRef } from 'react';
+/* eslint-disable no-unused-vars -- the legacy base rule misreads TypeScript callback signatures */
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { AlertCircle, AlertTriangle, Bell, CheckCircle2, Inbox, Info } from 'lucide-react';
 
 import { useNotification } from '../../contexts/NotificationContext';
 
 interface NotificationBellProps {
   onNotificationClick?: (notificationId: string) => void;
   permissionStatus?: 'granted' | 'denied' | 'default' | 'unknown';
+  tone?: 'light' | 'dark';
 }
 
-const NotificationBell: React.FC<NotificationBellProps> = ({ onNotificationClick, permissionStatus }) => {
+interface DropdownPosition {
+  top: number;
+  left: number;
+  width: number;
+  maxHeight: number;
+}
+
+const NotificationBell: React.FC<NotificationBellProps> = ({
+  onNotificationClick,
+  permissionStatus,
+  tone = 'light',
+}) => {
   const { unreadCount, recentNotifications, markAsRead } = useNotification();
   const [isOpen, setIsOpen] = useState(false);
-  const bellRef = useRef<HTMLDivElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<DropdownPosition>({ top: 72, left: 12, width: 340, maxHeight: 420 });
+  const bellRef = useRef<React.ElementRef<'button'>>(null);
+  const dropdownRef = useRef<React.ElementRef<'div'>>(null);
 
-  // Close dropdown when clicking outside
+  const sortedNotifications = useMemo(
+    () => [...recentNotifications].sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime()),
+    [recentNotifications],
+  );
+
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        bellRef.current &&
-        dropdownRef.current &&
-        !bellRef.current.contains(event.target as Node) &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: globalThis.PointerEvent) => {
+      const target = event.target as globalThis.Node;
+      if (!bellRef.current?.contains(target) && !dropdownRef.current?.contains(target)) {
         setIsOpen(false);
       }
     };
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+        bellRef.current?.focus();
+      }
+    };
 
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
 
-  const handleBellClick = () => {
-    setIsOpen(!isOpen);
-  };
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const updatePosition = () => {
+      const rect = bellRef.current?.getBoundingClientRect();
+      if (!rect) {
+        return;
+      }
+
+      const edge = 12;
+      const gap = 10;
+      const width = Math.min(360, window.innerWidth - (edge * 2));
+      const left = Math.min(Math.max(edge, rect.right - width), window.innerWidth - width - edge);
+      const below = window.innerHeight - rect.bottom - gap - edge;
+      const above = rect.top - gap - edge;
+      const openBelow = below >= 260 || below >= above;
+      const maxHeight = Math.max(220, Math.min(440, openBelow ? below : above));
+      const top = openBelow ? rect.bottom + gap : Math.max(edge, rect.top - maxHeight - gap);
+
+      setPosition({ top, left, width, maxHeight });
+    };
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [isOpen]);
 
   const handleNotificationClick = (notificationId: string) => {
     markAsRead(notificationId);
@@ -42,271 +100,84 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ onNotificationClick
   };
 
   const formatTimeAgo = (timestamp: Date): string => {
-    const now = new Date();
-    const diffInSeconds = Math.floor((now.getTime() - timestamp.getTime()) / 1000);
-
+    const diffInSeconds = Math.max(0, Math.floor((Date.now() - timestamp.getTime()) / 1000));
     if (diffInSeconds < 60) {
       return 'now';
     }
-
     const diffInMinutes = Math.floor(diffInSeconds / 60);
     if (diffInMinutes < 60) {
       return `${diffInMinutes}m`;
     }
-
     const diffInHours = Math.floor(diffInMinutes / 60);
     if (diffInHours < 24) {
       return `${diffInHours}h`;
     }
-
-    const diffInDays = Math.floor(diffInHours / 24);
-    return `${diffInDays}d`;
+    return `${Math.floor(diffInHours / 24)}d`;
   };
 
-  const getNotificationIcon = (type: string): string => {
+  const notificationIcon = (type: string) => {
     switch (type) {
-    case 'success': return '✅';
-    case 'error': return '❌';
-    case 'warning': return '⚠️';
-    case 'info': return 'ℹ️';
-    default: return '🔔';
+    case 'success': return <CheckCircle2 size={17} />;
+    case 'error': return <AlertCircle size={17} />;
+    case 'warning': return <AlertTriangle size={17} />;
+    default: return <Info size={17} />;
     }
   };
 
   return (
-    <div style={{ position: 'relative' }}>
-      {/* Bell Icon */}
-      <div
+    <div className={`notification-bell notification-bell--${tone}`}>
+      <button
         ref={bellRef}
-        onClick={handleBellClick}
-        style={{
-          position: 'relative',
-          width: '44px',
-          height: '44px',
-          borderRadius: '8px',
-          background: 'transparent',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          cursor: 'pointer',
-          transition: 'all 0.2s ease',
-          padding: '8px',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.background = 'rgba(0, 0, 0, 0.05)';
-          e.currentTarget.style.transform = 'scale(1.05)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.background = 'transparent';
-          e.currentTarget.style.transform = 'scale(1)';
-        }}
+        type="button"
+        className="notification-bell__trigger"
+        onClick={() => setIsOpen((open) => !open)}
+        aria-label="Notifications"
+        aria-expanded={isOpen}
       >
-        {/* Clean SVG Bell Icon */}
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          style={{
-            color: permissionStatus === 'denied' ? 'var(--text-muted)' : 'var(--text-primary)',
-            position: 'relative',
-            opacity: permissionStatus === 'denied' ? 0.6 : 1,
-            transition: 'all 0.2s ease',
-          }}
-        >
-          <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
-          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
-        </svg>
+        <Bell size={19} aria-hidden="true" opacity={permissionStatus === 'denied' ? 0.55 : 1} />
+        {unreadCount > 0 && <span className="notification-bell__badge">{unreadCount > 99 ? '99+' : unreadCount}</span>}
+      </button>
 
-        {/* Unread Badge */}
-        {unreadCount > 0 && (
-          <div style={{
-            position: 'absolute',
-            top: '6px',
-            right: '6px',
-            background: '#ef4444',
-            color: 'white',
-            borderRadius: '10px',
-            minWidth: '18px',
-            height: '18px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: '11px',
-            fontWeight: '600',
-            border: '2px solid var(--bg-primary)',
-            boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-          }}>
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </div>
-        )}
-      </div>
-
-      {/* Dropdown - Rendered via Portal to ensure it's above everything */}
       {isOpen && createPortal(
         <div
           ref={dropdownRef}
-          style={{
-            position: 'fixed',
-            top: '92px', // Header height (80px) + some padding
-            right: '16px',
-            width: '320px',
-            maxWidth: 'calc(100vw - 32px)',
-            background: 'var(--bg-primary)',
-            border: '1px solid var(--border-color)',
-            borderRadius: '12px',
-            boxShadow: '0 10px 25px rgba(0, 0, 0, 0.15)',
-            zIndex: 2147483647,
-            maxHeight: '400px',
-            overflow: 'hidden',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
+          className="notification-panel"
+          role="region"
+          aria-label="Notifications"
+          style={{ top: position.top, left: position.left, width: position.width, maxHeight: position.maxHeight }}
         >
-          {/* Header */}
-          <div style={{
-            padding: '16px',
-            borderBottom: '1px solid var(--border-color)',
-            background: 'var(--bg-secondary)',
-            borderRadius: '12px 12px 0 0',
-          }}>
-            <h3 style={{
-              fontSize: '16px',
-              fontWeight: '600',
-              color: 'var(--text-primary)',
-              margin: '0',
-            }}>
-              Notifications
-            </h3>
-            <p style={{
-              fontSize: '12px',
-              color: 'var(--text-muted)',
-              margin: '4px 0 0 0',
-            }}>
-              Past 12 hours
-            </p>
+          <div className="notification-panel__header">
+            <div><strong>Notifications</strong><span>Past 12 hours</span></div>
+            {unreadCount > 0 && <span>{unreadCount} new</span>}
           </div>
 
-          {/* Notifications List */}
-          <div style={{
-            flex: 1,
-            overflowY: 'auto',
-            maxHeight: '300px',
-          }}>
-            {recentNotifications.length === 0 ? (
-              <div style={{
-                padding: '40px 20px',
-                textAlign: 'center',
-                color: 'var(--text-muted)',
-              }}>
-                <span style={{ fontSize: '32px', marginBottom: '8px', display: 'block' }}>🔔</span>
-                <p style={{ fontSize: '14px', margin: '0' }}>No recent notifications</p>
+          <div className="notification-panel__list">
+            {sortedNotifications.length === 0 ? (
+              <div className="notification-panel__empty">
+                <Inbox size={25} />
+                <strong>All caught up</strong>
+                <span>No recent notifications</span>
               </div>
-            ) : (
-              recentNotifications
-                .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
-                .map((notification) => (
-                  <div
-                    key={notification.id}
-                    onClick={() => handleNotificationClick(notification.id)}
-                    style={{
-                      padding: '12px 16px',
-                      borderBottom: '1px solid var(--border-color)',
-                      cursor: 'pointer',
-                      background: notification.read ? 'transparent' : 'rgba(59, 130, 246, 0.05)',
-                      transition: 'background-color 0.2s ease',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '12px',
-                      minHeight: '48px',
-                    }}
-                    onMouseEnter={(e) => {
-                      e.currentTarget.style.background = notification.read
-                        ? 'rgba(0, 0, 0, 0.02)'
-                        : 'rgba(59, 130, 246, 0.08)';
-                    }}
-                    onMouseLeave={(e) => {
-                      e.currentTarget.style.background = notification.read
-                        ? 'transparent'
-                        : 'rgba(59, 130, 246, 0.05)';
-                    }}
-                  >
-                    {/* Icon */}
-                    <div style={{
-                      fontSize: '16px',
-                      flexShrink: 0,
-                    }}>
-                      {getNotificationIcon(notification.type)}
-                    </div>
-
-                    {/* Content - Single Line Only */}
-                    <div style={{
-                      flex: 1,
-                      minWidth: 0, // Allow text to truncate
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'center',
-                    }}>
-                      <div style={{
-                        fontSize: '13px', // Slightly smaller for mobile
-                        fontWeight: notification.read ? '400' : '500',
-                        color: 'var(--text-primary)',
-                        lineHeight: '1.2', // Tighter line height
-                        whiteSpace: 'nowrap', // NO WRAPPING
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis', // Show ... when truncated
-                        marginBottom: notification.message ? '1px' : '0',
-                      }}>
-                        {notification.title}
-                      </div>
-                      {notification.message && (
-                        <div style={{
-                          fontSize: '11px', // Smaller secondary text
-                          color: 'var(--text-muted)',
-                          lineHeight: '1.1', // Very tight
-                          whiteSpace: 'nowrap', // NO WRAPPING
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis', // Show ... when truncated
-                        }}>
-                          {notification.message}
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Time & Unread Dot */}
-                    <div style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'flex-end',
-                      gap: '2px',
-                      flexShrink: 0,
-                    }}>
-                      <span style={{
-                        fontSize: '11px',
-                        color: 'var(--text-muted)',
-                        whiteSpace: 'nowrap',
-                      }}>
-                        {formatTimeAgo(notification.timestamp)}
-                      </span>
-                      {!notification.read && (
-                        <div style={{
-                          width: '6px',
-                          height: '6px',
-                          borderRadius: '50%',
-                          background: '#ef4444',
-                        }} />
-                      )}
-                    </div>
-                  </div>
-                ))
-            )}
+            ) : sortedNotifications.map((notification) => (
+              <button
+                key={notification.id}
+                type="button"
+                className={notification.read ? 'notification-panel__item' : 'notification-panel__item is-unread'}
+                onClick={() => handleNotificationClick(notification.id)}
+              >
+                <span className={`notification-panel__type notification-panel__type--${notification.type}`}>
+                  {notificationIcon(notification.type)}
+                </span>
+                <span className="notification-panel__copy">
+                  <strong>{notification.title}</strong>
+                  {notification.message && <span>{notification.message}</span>}
+                </span>
+                <span className="notification-panel__time">{formatTimeAgo(notification.timestamp)}</span>
+              </button>
+            ))}
           </div>
         </div>,
-        document.body, // Portal target - renders at document root level
+        document.body,
       )}
     </div>
   );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import type { AuthResponse } from '@supabase/supabase-js';
 
-import type { User, AuthState } from '../types';
+import type { User } from '../types';
 import { authService } from '../services/auth';
 import { logger } from '../lib/logger';
 
@@ -19,6 +19,18 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const requireProfileUpdateData = (response: any): Partial<User> => {
+  if (response?.error) {
+    throw new Error(response.error.message || 'Profile changes could not be saved.');
+  }
+
+  if (!response?.data) {
+    throw new Error('Profile changes were not returned by the server.');
+  }
+
+  return response.data;
+};
 
 interface AuthProviderProps {
   children: ReactNode;
@@ -146,10 +158,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     if (!user) {
       throw new Error('No user logged in');
     }
+
     const response = await authService.updateUserProfile(user.id, updates);
-    if (response.data) {
-      setUser({ ...user, ...response.data });
-    }
+    const savedProfile = requireProfileUpdateData(response);
+
+    setUser((currentUser) => (
+      currentUser ? { ...currentUser, ...savedProfile } : currentUser
+    ));
     return response;
   };
 

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,15 +1,22 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 
 import i18n from '../i18n';
+import type { User } from '../types';
+
+import { useAuth } from './AuthContext';
 
 interface LanguageContextType {
-  currentLanguage: string;
-  changeLanguage: (language: string, updateProfile?: (data: any) => Promise<void>, user?: any) => Promise<void>;
-  isRTL: boolean;
+  currentLanguage: 'en';
+  changeLanguage: (
+    language: string,
+    updateProfile?: (data: Partial<User>) => Promise<unknown>,
+    user?: User | null,
+  ) => Promise<void>;
+  isRTL: false;
   isInitialized: boolean;
   isChanging: boolean;
-  isTranslating: boolean;
+  isTranslating: false;
 }
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
@@ -18,137 +25,73 @@ interface LanguageProviderProps {
   children: ReactNode;
 }
 
+export const getLanguageStorageKey = (userId: string): string => `language:${userId}`;
+
+export const normalizeSupportedLanguage = (_language?: string | null): 'en' => 'en';
+
+const enforceEnglishDocument = async () => {
+  await i18n.changeLanguage('en');
+  localStorage.setItem('language', 'en');
+  localStorage.setItem('i18nextLng', 'en');
+  document.documentElement.lang = 'en';
+  document.documentElement.dir = 'ltr';
+  document.documentElement.classList.remove('rtl');
+  document.documentElement.classList.add('ltr');
+  document.body.classList.remove('rtl');
+};
+
 export const LanguageProvider: React.FC<LanguageProviderProps> = ({ children }) => {
-  const [currentLanguage, setCurrentLanguage] = useState('en');
+  const { user: authenticatedUser } = useAuth();
   const [isInitialized, setIsInitialized] = useState(false);
   const [isChanging, setIsChanging] = useState(false);
-  const [isTranslating, setIsTranslating] = useState(false);
-
-  // RTL languages
-  const rtlLanguages = ['ar'];
 
   useEffect(() => {
-    const initializeLanguage = async () => {
-      try {
-        // Load language from localStorage or default to 'en'
-        const savedLanguage = localStorage.getItem('language') || 'en';
-
-        // Change i18n language first
-        await i18n.changeLanguage(savedLanguage);
-
-        // Then update state and DOM after i18n is ready
-        setCurrentLanguage(savedLanguage);
-
-        // Set initial direction after i18n is ready
-        const direction = rtlLanguages.includes(savedLanguage) ? 'rtl' : 'ltr';
-        document.documentElement.dir = direction;
-        document.documentElement.lang = savedLanguage;
-
-        if (rtlLanguages.includes(savedLanguage)) {
-          document.body.classList.add('rtl');
-        } else {
-          document.body.classList.remove('rtl');
-        }
-
-        setIsInitialized(true);
-        console.log(`Language initialized to ${savedLanguage} with direction ${direction}`);
-      } catch (error) {
-        console.error('Error initializing language:', error);
-        // Fallback to English
-        setCurrentLanguage('en');
-        setIsInitialized(true);
-      }
-    };
-
-    initializeLanguage();
+    enforceEnglishDocument()
+      .catch((error) => console.error('Error initializing English language:', error))
+      .finally(() => setIsInitialized(true));
   }, []);
 
-  // Listen for translation events to update isTranslating state
   useEffect(() => {
-    const handleMissingKey = () => {
-      // Use setTimeout to avoid updating state during render
-      setTimeout(() => {
-        setIsTranslating(true);
-        // Reset translating state after a short delay
-        setTimeout(() => setIsTranslating(false), 1000);
-      }, 0);
-    };
+    if (!isInitialized || !authenticatedUser) {
+      return;
+    }
 
-    const handleLanguageChanged = () => {
-      setIsTranslating(false);
-    };
+    localStorage.setItem(getLanguageStorageKey(authenticatedUser.id), 'en');
+  }, [authenticatedUser, isInitialized]);
 
-    i18n.on('missingKey', handleMissingKey);
-    i18n.on('languageChanged', handleLanguageChanged);
-
-    return () => {
-      i18n.off('missingKey', handleMissingKey);
-      i18n.off('languageChanged', handleLanguageChanged);
-    };
-  }, []);
-
-  const changeLanguage = async (language: string, updateProfile?: (data: any) => Promise<void>, user?: any) => {
-    // Prevent changing to the same language or if already changing
-    if (language === currentLanguage || isChanging) {
+  const changeLanguage = async (
+    _language: string,
+    updateProfile?: (data: Partial<User>) => Promise<unknown>,
+    user?: User | null,
+  ) => {
+    if (isChanging) {
       return;
     }
 
     setIsChanging(true);
-
     try {
-      // Update document direction and language immediately for instant visual feedback
-      const direction = rtlLanguages.includes(language) ? 'rtl' : 'ltr';
-      document.documentElement.dir = direction;
-      document.documentElement.lang = language;
+      await enforceEnglishDocument();
 
-      // Update body class for RTL styling
-      if (rtlLanguages.includes(language)) {
-        document.body.classList.add('rtl');
-      } else {
-        document.body.classList.remove('rtl');
+      if (user?.id) {
+        localStorage.setItem(getLanguageStorageKey(user.id), 'en');
       }
 
-      // Now change the i18n language
-      await i18n.changeLanguage(language);
-
-      // Update state after successful language change
-      setCurrentLanguage(language);
-
-      // Save to localStorage
-      localStorage.setItem('language', language);
-
-      // Update user profile if authenticated and updateProfile function is provided
-      if (user && updateProfile) {
-        await updateProfile({ language });
-      }
-
-      console.log(`Language changed to ${language} with direction ${direction}`);
-    } catch (error) {
-      console.error('Error changing language:', error);
-      // Revert direction changes on error
-      const currentDirection = rtlLanguages.includes(currentLanguage) ? 'rtl' : 'ltr';
-      document.documentElement.dir = currentDirection;
-      document.documentElement.lang = currentLanguage;
-      if (rtlLanguages.includes(currentLanguage)) {
-        document.body.classList.add('rtl');
-      } else {
-        document.body.classList.remove('rtl');
+      if (user && updateProfile && user.language !== 'en') {
+        await updateProfile({ language: 'en' });
       }
     } finally {
       setIsChanging(false);
     }
   };
 
-  const isRTL = rtlLanguages.includes(currentLanguage);
-
   return (
     <LanguageContext.Provider value={{
-      currentLanguage,
+      currentLanguage: 'en',
       changeLanguage,
-      isRTL,
+      isRTL: false,
       isInitialized,
       isChanging,
-      isTranslating,
+      isTranslating: false,
     }}>
       {children}
     </LanguageContext.Provider>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,13 +1,14 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState, ReactNode } from 'react';
 
 import { storageManager } from '../lib/storage';
-import { userLocationService } from '../services/userLocationService';
 import { supabase } from '../lib/supabase';
+import { userLocationService } from '../services/userLocationService';
 
-// Callback type for location sharing changes
+import { useAuth } from './AuthContext';
+
 export type LocationSharingChangeCallback = () => void;
 
-interface Settings {
+export interface Settings {
   notifications: boolean;
   locationSharing: boolean;
   notificationRadius: number;
@@ -16,15 +17,31 @@ interface Settings {
 
 interface SettingsContextType {
   settings: Settings;
-  updateSettings: (newSettings: Partial<Settings>) => void;
+  updateSettings: (newSettings: Partial<Settings>) => Promise<void>;
   isLoading: boolean;
 }
 
-const defaultSettings: Settings = {
+export const defaultSettings: Settings = {
   notifications: true,
   locationSharing: false,
   notificationRadius: 5,
   hideNearbyUsers: false,
+};
+
+export const getSettingsStorageKey = (userId?: string | null): string => (
+  `userSettings:${userId || 'guest'}`
+);
+
+export const parseStoredSettings = (value: string | null): Settings => {
+  if (!value) {
+    return defaultSettings;
+  }
+
+  try {
+    return { ...defaultSettings, ...JSON.parse(value) };
+  } catch {
+    return defaultSettings;
+  }
 };
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -34,65 +51,103 @@ interface SettingsProviderProps {
 }
 
 export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) => {
+  const { user } = useAuth();
   const [settings, setSettings] = useState<Settings>(defaultSettings);
+  const settingsRef = useRef<Settings>(defaultSettings);
   const [isLoading, setIsLoading] = useState(true);
+  const storageKey = getSettingsStorageKey(user?.id);
 
-  // Load settings from storage on mount
   useEffect(() => {
+    let isActive = true;
+
     const loadSettings = async () => {
+      setIsLoading(true);
+
       try {
-        const storedSettings = await storageManager.get('userSettings');
-        if (storedSettings) {
-          const parsedSettings = JSON.parse(storedSettings);
-          // Merge with defaults to handle new settings
-          setSettings({ ...defaultSettings, ...parsedSettings });
+        let storedSettings = await storageManager.get(storageKey);
+
+        // Migrate the previous unscoped key once, without leaking it to future accounts.
+        if (!storedSettings && user?.id) {
+          storedSettings = await storageManager.get('userSettings');
+          if (storedSettings) {
+            await storageManager.remove('userSettings');
+          }
+        }
+
+        const loadedSettings = parseStoredSettings(storedSettings);
+
+        if (user?.id) {
+          const { data, error } = await supabase
+            .from('users')
+            .select('location_sharing')
+            .eq('user_id', user.id)
+            .limit(2);
+
+          if (!error && data?.length === 1 && typeof data[0].location_sharing === 'boolean') {
+            loadedSettings.locationSharing = data[0].location_sharing;
+          } else if (!error && data && data.length > 1) {
+            console.error('Duplicate profile records found while loading settings.');
+          }
+        }
+
+        if (isActive) {
+          settingsRef.current = loadedSettings;
+          setSettings(loadedSettings);
+          await storageManager.set(storageKey, JSON.stringify(loadedSettings));
         }
       } catch (error) {
         console.error('Error loading settings:', error);
+        if (isActive) {
+          settingsRef.current = defaultSettings;
+          setSettings(defaultSettings);
+        }
       } finally {
-        setIsLoading(false);
+        if (isActive) {
+          setIsLoading(false);
+        }
       }
     };
 
     loadSettings();
-  }, []);
 
-  // Save settings to storage whenever they change
-  const updateSettings = async (newSettings: Partial<Settings>) => {
-    const updatedSettings = { ...settings, ...newSettings };
+    return () => {
+      isActive = false;
+    };
+  }, [storageKey, user?.id]);
+
+  const updateSettings = async (newSettings: Partial<Settings>): Promise<void> => {
+    const previousSettings = settingsRef.current;
+    const updatedSettings = { ...previousSettings, ...newSettings };
+
+    settingsRef.current = updatedSettings;
     setSettings(updatedSettings);
+    await storageManager.set(storageKey, JSON.stringify(updatedSettings));
 
     try {
-      await storageManager.set('userSettings', JSON.stringify(updatedSettings));
-      console.log('Settings updated:', updatedSettings);
+      if (
+        user?.id &&
+        newSettings.locationSharing !== undefined &&
+        newSettings.locationSharing !== previousSettings.locationSharing
+      ) {
+        const success = await userLocationService.updateLocationSharingPreference(
+          user.id,
+          newSettings.locationSharing,
+        );
 
-      // Sync location sharing preference with server if it changed
-      if (newSettings.locationSharing !== undefined && newSettings.locationSharing !== settings.locationSharing) {
-        try {
-          const { data: { user } } = await supabase.auth.getUser();
-          if (user) {
-            const success = await userLocationService.updateLocationSharingPreference(user.id, newSettings.locationSharing);
-            if (!success) {
-              console.error('Failed to sync location sharing preference with server');
-            }
-          }
-        } catch (error) {
-          console.error('Error syncing location sharing with server:', error);
+        if (!success) {
+          throw new Error('Location sharing could not be saved to your account.');
         }
       }
     } catch (error) {
-      console.error('Error saving settings:', error);
+      settingsRef.current = previousSettings;
+      setSettings(previousSettings);
+      await storageManager.set(storageKey, JSON.stringify(previousSettings));
+      throw error;
     }
   };
 
-  const value: SettingsContextType = {
-    settings,
-    updateSettings,
-    isLoading,
-  };
-
   return (
-    <SettingsContext.Provider value={value}>
+    <SettingsContext.Provider value={{ settings, updateSettings, isLoading }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/src/contexts/persistence.test.tsx
+++ b/src/contexts/persistence.test.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  user: { id: 'user-a', email: 'user@example.com' } as { id: string; email: string } | null,
+  storageGet: vi.fn(),
+  storageSet: vi.fn(),
+  storageRemove: vi.fn(),
+  limitProfiles: vi.fn(),
+  updateLocationSharingPreference: vi.fn(),
+}));
+
+vi.mock('./AuthContext', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./AuthContext')>();
+  return {
+    ...original,
+    useAuth: () => ({ user: mocks.user }),
+  };
+});
+
+vi.mock('../lib/storage', () => ({
+  storageManager: {
+    get: mocks.storageGet,
+    set: mocks.storageSet,
+    remove: mocks.storageRemove,
+  },
+}));
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ limit: mocks.limitProfiles })),
+      })),
+    })),
+  },
+}));
+
+vi.mock('../services/userLocationService', () => ({
+  userLocationService: {
+    updateLocationSharingPreference: mocks.updateLocationSharingPreference,
+  },
+}));
+
+import { requireProfileUpdateData } from './AuthContext';
+import {
+  buildAuthProfileMetadata,
+  buildProfileUpsertPayload,
+  mergeAuthIdentity,
+  resolveProfileRow,
+  sanitizeProfileUpdates,
+} from '../services/auth';
+import { getLanguageStorageKey, normalizeSupportedLanguage } from './LanguageContext';
+import {
+  SettingsProvider,
+  getSettingsStorageKey,
+  useSettings,
+} from './SettingsContext';
+
+let currentSettings: ReturnType<typeof useSettings>;
+
+const SettingsProbe: React.FC = () => {
+  currentSettings = useSettings();
+  return <div data-testid="settings-state">{JSON.stringify(currentSettings.settings)}</div>;
+};
+
+describe('profile and settings persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.user = { id: 'user-a', email: 'user@example.com' };
+    mocks.storageSet.mockResolvedValue(undefined);
+    mocks.storageRemove.mockResolvedValue(undefined);
+    mocks.limitProfiles.mockResolvedValue({ data: [{ location_sharing: false }], error: null });
+    mocks.updateLocationSharingPreference.mockResolvedValue(true);
+  });
+
+  it('uses account-scoped storage keys', () => {
+    expect(getSettingsStorageKey('user-a')).toBe('userSettings:user-a');
+    expect(getSettingsStorageKey('user-b')).toBe('userSettings:user-b');
+    expect(getLanguageStorageKey('user-a')).toBe('language:user-a');
+    expect(normalizeSupportedLanguage('ar')).toBe('en');
+  });
+
+  it('hydrates local settings and lets the server override durable location sharing', async () => {
+    mocks.storageGet.mockImplementation(async (key: string) => (
+      key === 'userSettings:user-a'
+        ? JSON.stringify({ notifications: false, locationSharing: false })
+        : null
+    ));
+    mocks.limitProfiles.mockResolvedValue({ data: [{ location_sharing: true }], error: null });
+
+    render(
+      <SettingsProvider>
+        <SettingsProbe />
+      </SettingsProvider>,
+    );
+
+    await waitFor(() => expect(currentSettings.isLoading).toBe(false));
+    expect(currentSettings.settings.notifications).toBe(false);
+    expect(currentSettings.settings.locationSharing).toBe(true);
+    expect(mocks.storageGet).toHaveBeenCalledWith('userSettings:user-a');
+    expect(mocks.storageSet).toHaveBeenCalledWith(
+      'userSettings:user-a',
+      expect.stringContaining('"locationSharing":true'),
+    );
+  });
+
+  it('persists a preference update under the current account', async () => {
+    mocks.storageGet.mockResolvedValue(JSON.stringify({ notifications: true }));
+
+    render(
+      <SettingsProvider>
+        <SettingsProbe />
+      </SettingsProvider>,
+    );
+    await waitFor(() => expect(currentSettings.isLoading).toBe(false));
+
+    await act(async () => {
+      await currentSettings.updateSettings({ notifications: false });
+    });
+
+    expect(currentSettings.settings.notifications).toBe(false);
+    expect(mocks.storageSet).toHaveBeenLastCalledWith(
+      'userSettings:user-a',
+      expect.stringContaining('"notifications":false'),
+    );
+  });
+
+  it('rolls back location sharing when the durable server write fails', async () => {
+    mocks.storageGet.mockResolvedValue(JSON.stringify({ locationSharing: false }));
+    mocks.updateLocationSharingPreference.mockResolvedValue(false);
+
+    render(
+      <SettingsProvider>
+        <SettingsProbe />
+      </SettingsProvider>,
+    );
+    await waitFor(() => expect(currentSettings.isLoading).toBe(false));
+
+    let saveError: unknown;
+    await act(async () => {
+      try {
+        await currentSettings.updateSettings({ locationSharing: true });
+      } catch (error) {
+        saveError = error;
+      }
+    });
+    expect(saveError).toBeInstanceOf(Error);
+    expect((saveError as Error).message).toContain('could not be saved');
+
+    await waitFor(() => {
+      expect(currentSettings.settings.locationSharing).toBe(false);
+      expect(mocks.storageSet).toHaveBeenLastCalledWith(
+        'userSettings:user-a',
+        expect.stringContaining('"locationSharing":false'),
+      );
+    });
+  });
+
+  it('rejects failed or empty profile saves instead of presenting them as successful', () => {
+    expect(() => requireProfileUpdateData({ error: { message: 'Row update denied' } }))
+      .toThrow('Row update denied');
+    expect(() => requireProfileUpdateData({ data: null, error: null }))
+      .toThrow('not returned by the server');
+    expect(requireProfileUpdateData({ data: { first_name: 'Amina' }, error: null }))
+      .toEqual({ first_name: 'Amina' });
+  });
+
+  it('handles profile query cardinality without PostgREST single-row coercion', () => {
+    expect(resolveProfileRow([], 'load', true)).toEqual({ data: null, error: null });
+
+    const missingUpdate = resolveProfileRow([], 'update');
+    expect(missingUpdate.data).toBeNull();
+    expect(missingUpdate.error?.code).toBe('PROFILE_NOT_FOUND');
+
+    const duplicateUpdate = resolveProfileRow(
+      [{ user_id: 'user-a' }, { user_id: 'user-a' }],
+      'update',
+    );
+    expect(duplicateUpdate.data).toBeNull();
+    expect(duplicateUpdate.error?.code).toBe('PROFILE_DUPLICATE');
+
+    expect(resolveProfileRow([{ user_id: 'user-a' }], 'update')).toEqual({
+      data: { user_id: 'user-a' },
+      error: null,
+    });
+  });
+
+  it('keeps the Supabase Auth ID when a profile row has its own primary key', () => {
+    const merged = mergeAuthIdentity(
+      {
+        id: 'auth-user-id',
+        email: 'auth@example.com',
+        email_confirmed_at: '2026-08-03T00:00:00.000Z',
+      },
+      {
+        id: 'public-profile-row-id',
+        email: 'stale@example.com',
+        first_name: 'Amina',
+      },
+    );
+
+    expect(merged.id).toBe('auth-user-id');
+    expect(merged.email).toBe('auth@example.com');
+    expect(merged.first_name).toBe('Amina');
+  });
+
+  it('builds a safe self-healing profile row without overwriting database identity fields', () => {
+    const updates = sanitizeProfileUpdates({
+      id: 'client-side-auth-id',
+      first_name: 'Amina',
+      last_name: 'Khaled',
+    });
+
+    expect(updates).toEqual({ first_name: 'Amina', last_name: 'Khaled' });
+    expect(buildProfileUpsertPayload('auth-user-id', updates, {
+      email: 'amina@example.com',
+      username: 'amina',
+    })).toEqual(expect.objectContaining({
+      user_id: 'auth-user-id',
+      email: 'amina@example.com',
+      username: 'amina',
+      first_name: 'Amina',
+      last_name: 'Khaled',
+    }));
+
+    expect(buildAuthProfileMetadata({
+      first_name: 'Amina',
+      reputation: 999,
+      verification_level: 'trusted',
+    })).toEqual({ first_name: 'Amina' });
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,54 +1,9 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
 
-// Import translation files
 import enTranslations from './locales/en.json';
-import arTranslations from './locales/ar.json';
 import commonEnTranslations from './locales/common.json';
-import commonArTranslations from './locales/common.ar.json';
-import { translationService } from './services/translationService';
-import {
-  formatDate,
-  formatTime,
-  formatDateTime,
-  formatRelativeTime,
-  formatNumber,
-  formatCurrency,
-  formatPercent,
-  formatDistance,
-  formatTemperature,
-  formatSpeed,
-  formatFileSize,
-  formatDuration,
-} from './lib/i18nUtils';
 
-// Arabic pluralization rules - FIXED
-const arabicPluralization = (count: number, ordinal?: boolean) => {
-  if (ordinal) {
-    return 'ordinal';
-  }
-
-  const absoluteCount = Math.abs(count);
-
-  if (absoluteCount === 0) {
-    return 'zero';
-  }
-  if (absoluteCount === 1) {
-    return 'singular';
-  }
-  if (absoluteCount === 2) {
-    return 'dual';
-  }
-  if (absoluteCount >= 3 && absoluteCount <= 10) {
-    return 'plural_few';
-  }
-
-  // 11 and above
-  return 'plural_many';
-};
-
-// Merge common translations with main translations
 const resources = {
   en: {
     translation: {
@@ -56,412 +11,41 @@ const resources = {
       ...enTranslations,
     },
   },
-  ar: {
-    translation: {
-      ...commonArTranslations,
-      ...arTranslations,
-    },
-  },
 };
 
-// Track missing keys to avoid duplicate translation requests
-const translatingKeys = new Set<string>();
-
-// Cache for translations to avoid repeated API calls
-const translationCache = new Map<string, string>();
-
-// Function to check if text is Arabic
-const isArabicText = (text: string): boolean => {
-  if (!text || typeof text !== 'string') {
-    return false;
+const applyEnglishDocumentSettings = () => {
+  if (typeof document === 'undefined') {
+    return;
   }
 
-  // Arabic Unicode range: U+0600 to U+06FF, U+0750 to U+077F, U+08A0 to U+08FF, U+FB50 to U+FDFF, U+FE70 to U+FEFF
-  const arabicRegex = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/;
-  return arabicRegex.test(text);
+  document.documentElement.lang = 'en';
+  document.documentElement.dir = 'ltr';
+  document.documentElement.classList.remove('rtl');
+  document.documentElement.classList.add('ltr');
+  document.body?.classList.remove('rtl');
 };
 
-// Function to safely get English text without recursion
-const getEnglishTextSafely = (key: string, fallbackValue: string): string => {
-  try {
-    // Direct access to English resources
-    const enResources = resources.en?.translation;
-    if (enResources && typeof enResources === 'object') {
-      // Navigate nested objects using dot notation
-      const keys = key.split('.');
-      let current: any = enResources;
-
-      for (const k of keys) {
-        if (current && typeof current === 'object' && k in current) {
-          current = current[k];
-        } else {
-          return fallbackValue;
-        }
-      }
-
-      if (typeof current === 'string' && current.trim() !== '') {
-        return current;
-      }
-    }
-  } catch (error) {
-    console.warn(`Error accessing English text for key "${key}":`, error);
-  }
-
-  return fallbackValue;
-};
-
-// CRITICAL: Pre-process Arabic translations to ensure they're properly formatted
-const processArabicTranslations = () => {
-  try {
-    const arResources = resources.ar?.translation;
-    if (!arResources) {
-      return;
-    }
-
-    // Clean up common issues in Arabic translations
-    const cleanup = (obj: any, path: string = ''): void => {
-      if (!obj || typeof obj !== 'object') {
-        return;
-      }
-
-      Object.keys(obj).forEach(key => {
-        const fullPath = path ? `${path}.${key}` : key;
-        const value = obj[key];
-
-        if (typeof value === 'string') {
-          // Clean up Arabic text
-          let cleaned = value.trim();
-
-          // Remove any remaining English placeholders
-          cleaned = cleaned.replace(/{{.*?}}/g, match => match); // Keep template variables
-
-          // Fix common spacing issues in Arabic
-          cleaned = cleaned.replace(/\s+/g, ' ');
-          cleaned = cleaned.replace(/(\S)\./g, '$1.');
-          cleaned = cleaned.replace(/،\s*/g, '، ');
-
-          obj[key] = cleaned;
-        } else if (typeof value === 'object' && value !== null) {
-          cleanup(value, fullPath);
-        }
-      });
-    };
-
-    cleanup(arResources);
-    console.log('✅ Arabic translations pre-processed');
-  } catch (error) {
-    console.warn('⚠️ Error processing Arabic translations:', error);
-  }
-};
-
-// Initialize i18n
 i18n
-  .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources,
-    lng: 'en', // default language
-    fallbackLng: {
-      'ar': ['en'],
-      'default': ['en'],
-    },
-
-    // Enable debug only in development
-    debug: process.env.NODE_ENV === 'development',
-
-    interpolation: {
-      escapeValue: false, // React already escapes values
-      format: (value: any, format?: string, lng?: string): string => {
-        // Handle advanced formatting
-        if (format) {
-          switch (format) {
-          // Date/Time formatting
-          case 'date':
-            return formatDate(value);
-          case 'time':
-            return formatTime(value);
-          case 'datetime':
-            return formatDateTime(value);
-          case 'relativeTime':
-            return formatRelativeTime(value);
-
-            // Number formatting
-          case 'number':
-            return formatNumber(value);
-          case 'currency':
-            return formatCurrency(value);
-          case 'percent':
-            return formatPercent(value);
-
-            // Custom formatters
-          case 'distance':
-            return formatDistance(value);
-          case 'temperature':
-            return formatTemperature(value);
-          case 'speed':
-            return formatSpeed(value);
-          case 'fileSize':
-            return formatFileSize(value);
-          case 'duration':
-            return formatDuration(value);
-
-            // Arabic numeral conversion
-          case 'arabicNumerals':
-            if (typeof value === 'string' && lng === 'ar') {
-              return convertToArabicNumerals(value);
-            }
-            return value;
-
-          default:
-            // Check for custom format options like 'currency:EUR' or 'date:short'
-            const [formatter, option] = format.split(':');
-            switch (formatter) {
-            case 'currency':
-              return formatCurrency(value, option || 'USD');
-            case 'date':
-              if (option === 'short') {
-                return formatDate(value, { dateStyle: 'short' });
-              } else if (option === 'long') {
-                return formatDate(value, { dateStyle: 'long' });
-              }
-              return formatDate(value);
-            case 'time':
-              if (option === 'short') {
-                return formatTime(value, { timeStyle: 'short' });
-              }
-              return formatTime(value);
-            case 'number':
-              if (option === 'integer') {
-                return formatNumber(value, { maximumFractionDigits: 0 });
-              }
-              return formatNumber(value);
-            case 'temperature':
-              return formatTemperature(value, (option as 'C' | 'F') || 'C');
-            case 'speed':
-              return formatSpeed(value, (option as 'kmh' | 'mph') || 'kmh');
-            }
-            break;
-          }
-        }
-
-        // Default: Convert numerals to Arabic when language is Arabic
-        if (typeof value === 'string' && lng === 'ar') {
-          return convertToArabicNumerals(value);
-        }
-        return value;
-      },
-    },
-
+    lng: 'en',
+    fallbackLng: 'en',
+    supportedLngs: ['en'],
+    debug: false,
+    interpolation: { escapeValue: false },
     react: {
       useSuspense: false,
       bindI18n: 'languageChanged loaded',
       bindI18nStore: 'added removed',
     },
-
-    // Language detection configuration
-    detection: {
-      order: ['localStorage', 'navigator', 'htmlTag'],
-      lookupLocalStorage: 'i18nextLng',
-      caches: ['localStorage'],
-    },
-
-    // Handle missing keys - OPTIMIZED FOR ARABIC
-    missingKeyHandler: async (lngs: readonly string[], ns: string, key: string, fallbackValue: string) => {
-      const targetLang = lngs[0];
-
-      // Only handle Arabic translations
-      if (targetLang !== 'ar') {
-        return fallbackValue;
-      }
-
-      // Skip keys that are likely not user-facing text
-      if (key.startsWith('_') || key.includes('__') ||
-          key.toLowerCase().includes('api') ||
-          key.toLowerCase().includes('url') ||
-          key.toLowerCase().includes('endpoint')) {
-        return fallbackValue;
-      }
-
-      // Check cache first
-      const cacheKey = `en-ar-${key}`;
-      if (translationCache.has(cacheKey)) {
-        return translationCache.get(cacheKey) || fallbackValue;
-      }
-
-      // Skip if already translating this key
-      if (translatingKeys.has(cacheKey)) {
-        return fallbackValue;
-      }
-
-      try {
-        translatingKeys.add(cacheKey);
-
-        // Get source text safely
-        const sourceText = getEnglishTextSafely(key, fallbackValue);
-
-        // Skip if not valid for translation
-        if (!sourceText ||
-            sourceText === key ||
-            sourceText === fallbackValue ||
-            sourceText.trim() === '' ||
-            isArabicText(sourceText)) {
-          return fallbackValue;
-        }
-
-        // Skip short technical texts
-        if (sourceText.length < 3 ||
-            /^[A-Z_]+$/.test(sourceText) || // UPPERCASE_WITH_UNDERSCORES
-            /^[0-9]+$/.test(sourceText)) {  // Numbers only
-          return fallbackValue;
-        }
-
-        // Translate using service
-        const translatedText = await translationService.translate(
-          sourceText,
-          'en',
-          'ar',
-        );
-
-        // Validate translated text
-        if (translatedText &&
-            translatedText !== sourceText &&
-            translatedText.trim() !== '' &&
-            isArabicText(translatedText)) {
-
-          // Cache the translation
-          translationCache.set(cacheKey, translatedText);
-
-          // Add to resources
-          i18n.addResource('ar', ns, key, translatedText);
-
-          // Emit event for UI updates
-          i18n.emit('added');
-
-          console.log(`✅ Translated: "${sourceText.substring(0, 50)}..." → "${translatedText.substring(0, 50)}..."`);
-
-          return translatedText;
-        }
-
-        return fallbackValue;
-
-      } catch (error) {
-        console.warn(`❌ Translation failed for key "${key}":`, error);
-        return fallbackValue;
-      } finally {
-        translatingKeys.delete(cacheKey);
-      }
-    },
-
-    // Configure saveMissing
-    saveMissing: process.env.NODE_ENV === 'development',
+    saveMissing: false,
   });
 
-// Process Arabic translations after init
-i18n.on('initialized', (options: any) => {
-  processArabicTranslations();
+applyEnglishDocumentSettings();
+i18n.on('languageChanged', applyEnglishDocumentSettings);
 
-  // Configure Arabic pluralization
-  setTimeout(() => {
-    try {
-      if (i18n.services?.pluralResolver) {
-        i18n.services.pluralResolver.addRule('ar', {
-          name: 'arabic',
-          numbers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 100],
-          plurals: arabicPluralization,
-        });
-
-        console.log('✅ Arabic pluralization configured');
-      }
-    } catch (error) {
-      console.warn('⚠️ Error configuring Arabic pluralization:', error);
-    }
-  }, 500);
-});
-
-// Handle language changes
-i18n.on('languageChanged', (lng: string) => {
-  // Update direction for RTL languages
-  const isRTL = lng === 'ar';
-  document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
-  document.documentElement.lang = lng;
-
-  // Add language class for CSS
-  document.documentElement.classList.toggle('rtl', isRTL);
-  document.documentElement.classList.toggle('ltr', !isRTL);
-
-  console.log(`🌐 Language changed to: ${lng} (${isRTL ? 'RTL' : 'LTR'})`);
-});
-
-// RTL languages
-export const rtlLanguages = ['ar'];
-
-// Helper function to check if current language is RTL
-export const isRTL = (): boolean => {
-  return rtlLanguages.includes(i18n.language);
-};
-
-// Function to convert Western Arabic numerals to Eastern Arabic numerals
-const convertToArabicNumerals = (text: string): string => {
-  if (!text || typeof text !== 'string') {
-    return text;
-  }
-
-  const numeralMap: { [key: string]: string } = {
-    '0': '٠',
-    '1': '١',
-    '2': '٢',
-    '3': '٣',
-    '4': '٤',
-    '5': '٥',
-    '6': '٦',
-    '7': '٧',
-    '8': '٨',
-    '9': '٩',
-  };
-
-  return text.replace(/[0-9]/g, (digit) => numeralMap[digit]);
-};
-
-// Function to convert Eastern Arabic numerals to Western Arabic numerals
-export const convertToWesternNumerals = (text: string): string => {
-  if (!text || typeof text !== 'string') {
-    return text;
-  }
-
-  const numeralMap: { [key: string]: string } = {
-    '٠': '0',
-    '١': '1',
-    '٢': '2',
-    '٣': '3',
-    '٤': '4',
-    '٥': '5',
-    '٦': '6',
-    '٧': '7',
-    '٨': '8',
-    '٩': '9',
-  };
-
-  return text.replace(/[٠-٩]/g, (digit) => numeralMap[digit]);
-};
-
-// Helper function to manually add Arabic translation
-export const addArabicTranslation = (key: string, arabicText: string): void => {
-  if (!key || !arabicText || !isArabicText(arabicText)) {
-    console.warn('Invalid Arabic translation data');
-    return;
-  }
-
-  // Add to cache
-  const cacheKey = `en-ar-${key}`;
-  translationCache.set(cacheKey, arabicText);
-
-  // Add to resources
-  i18n.addResource('ar', 'translation', key, arabicText);
-
-  // Emit update
-  i18n.emit('added');
-
-  console.log(`📝 Manual Arabic translation added: "${key}"`);
-};
+export const rtlLanguages: readonly string[] = [];
+export const isRTL = (): boolean => false;
 
 export default i18n;

--- a/src/index.css
+++ b/src/index.css
@@ -10,60 +10,6 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.hyper-ai-launcher {
-  position: fixed;
-  right: max(20px, env(safe-area-inset-right));
-  bottom: max(22px, env(safe-area-inset-bottom));
-  z-index: 1050;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 48px;
-  padding: 0 18px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-  background: linear-gradient(135deg, #111318 0%, #2d333b 100%);
-  color: #fff;
-  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.28);
-  cursor: pointer;
-  font: inherit;
-  font-size: 14px;
-  font-weight: 750;
-  letter-spacing: -0.01em;
-  transition: transform 160ms ease, box-shadow 160ms ease;
-}
-
-.hyper-ai-launcher:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.34);
-}
-
-.hyper-ai-launcher:focus-visible {
-  outline: 3px solid rgba(59, 130, 246, 0.45);
-  outline-offset: 3px;
-}
-
-@media (max-width: 767px) {
-  .hyper-ai-launcher {
-    right: max(14px, env(safe-area-inset-right));
-    bottom: calc(76px + env(safe-area-inset-bottom));
-    min-width: 48px;
-    width: 48px;
-    padding: 0;
-  }
-
-  .hyper-ai-launcher span {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    white-space: nowrap;
-  }
-}
-
 ::-webkit-scrollbar { width: 4px; height: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--wire); border-radius: 4px; }
@@ -292,11 +238,6 @@ input::placeholder {
   color: var(--t3) !important;
 }
 
-/* Chakra Button color overrides */
-[role="button"],
-button {
-  color: var(--t1) !important;
-}
 
 /* Tab styling */
 [role="tab"] {
@@ -1556,4 +1497,231 @@ select:active {
     padding: 10px !important;
     font-size: 14px !important;
   }
+}
+
+/* App shell refinement */
+html,
+body,
+#root {
+  min-height: 100dvh;
+}
+
+body {
+  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif !important;
+  background:
+    radial-gradient(circle at top left, rgba(0, 200, 150, 0.12), transparent 28%),
+    radial-gradient(circle at top right, rgba(79, 142, 247, 0.08), transparent 24%),
+    linear-gradient(180deg, #0b0d12 0%, #09090b 42%, #070708 100%) !important;
+}
+
+#root {
+  width: 100%;
+  overflow: hidden;
+}
+
+.app-layout {
+  min-height: 100dvh;
+  background: transparent;
+  isolation: isolate;
+}
+
+.app-main {
+  min-width: 0;
+  background: linear-gradient(180deg, rgba(9, 9, 11, 0.74) 0%, rgba(9, 9, 11, 0.92) 100%);
+}
+
+.app-content-desktop {
+  min-height: 0;
+  padding: clamp(14px, 1.8vw, 24px);
+  padding-bottom: clamp(18px, 2vw, 26px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-gutter: stable;
+}
+
+.app-content-shell {
+  width: min(100%, 1480px);
+  margin: 0 auto;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.app-content-shell > * {
+  min-width: 0;
+}
+
+.app-content-shell--map {
+  width: 100%;
+  max-width: none;
+  gap: 0;
+}
+
+.app-content-shell--map > * {
+  min-height: calc(100dvh - 168px);
+}
+
+.app-sidebar {
+  width: 264px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(17, 19, 24, 0.96) 0%, rgba(13, 15, 20, 0.96) 100%);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  height: 100dvh;
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 80;
+  padding: 22px 14px;
+  overflow-y: auto;
+  box-shadow: 12px 0 40px rgba(0, 0, 0, 0.22);
+}
+
+.app-main {
+  margin-left: 264px;
+}
+
+.app-header-desktop {
+  min-height: 72px;
+}
+
+@media (max-width: 1023px) {
+  .app-main {
+    margin-left: 0;
+  }
+
+  .app-content-desktop {
+    padding: 12px 12px 96px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .app-content-shell {
+    width: 100%;
+    gap: 16px;
+  }
+
+  .app-content-shell--map > * {
+    min-height: calc(100dvh - 160px);
+  }
+}
+
+
+
+/* Light shell overrides */
+body {
+  background:
+    radial-gradient(circle at top left, rgba(0, 168, 125, 0.08), transparent 28%),
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.06), transparent 24%),
+    linear-gradient(180deg, #f8fafc 0%, #f3f4f6 100%) !important;
+  color: #0f172a !important;
+}
+
+.app-main {
+  background: transparent !important;
+}
+
+.app-layout {
+  background: transparent !important;
+}
+
+.app-content-desktop {
+  background: transparent !important;
+}
+
+.tab-navigation {
+  background: rgba(255, 255, 255, 0.96) !important;
+}
+
+.tab-more-menu {
+  position: absolute;
+  right: 12px;
+  bottom: calc(100% + 10px);
+  width: min(220px, calc(100vw - 24px));
+  padding: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 22px 55px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(18px);
+}
+
+.tab-more-menu__item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 11px 12px;
+  border: 0;
+  border-radius: 13px;
+  color: #475569;
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.tab-more-menu__item:hover,
+.tab-more-menu__item.is-active {
+  color: #0f172a;
+  background: #f1f5f9;
+}
+
+.tab-more-toggle {
+  flex: 1;
+  min-height: 56px;
+  padding: 6px 0 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  border: 0;
+  color: #111827;
+  background: transparent;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.tab-more-toggle__icon {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 13px;
+}
+
+.tab-more-toggle.is-active { font-weight: 700; }
+
+.tab-more-toggle.is-active .tab-more-toggle__icon {
+  border-color: rgba(15, 23, 42, 0.16);
+  background: #fff;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+[dir='rtl'] .tab-more-menu { right: auto; left: 12px; }
+
+@media (min-width: 1024px) {
+  .app-sidebar { display: flex !important; }
+  .app-main { margin-left: 264px !important; margin-right: 0 !important; }
+  .tab-navigation { display: none !important; }
+
+  [dir='rtl'] .app-sidebar {
+    right: 0;
+    left: auto;
+    border-right: 0;
+    border-left: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  [dir='rtl'] .app-main { margin-right: 264px !important; margin-left: 0 !important; }
+}
+
+@media (max-width: 1023px) {
+  .app-sidebar { display: none !important; }
+  .app-main { margin-left: 0 !important; margin-right: 0 !important; }
 }

--- a/src/lib/dashboardAnalytics.test.ts
+++ b/src/lib/dashboardAnalytics.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { VibeType, type SOS, type Vibe } from '../types';
+
+import {
+  buildAreaSummaries,
+  buildAttentionItems,
+  buildDashboardMetrics,
+  buildVibeDistribution,
+  buildWeeklyTrend,
+} from './dashboardAnalytics';
+
+const NOW = new Date('2026-08-03T12:00:00.000Z');
+
+function report(
+  id: number,
+  vibeType: VibeType,
+  createdAt: string,
+  overrides: Partial<Vibe> = {},
+): Vibe {
+  return {
+    id,
+    user_id: `user-${id}`,
+    vibe_type: vibeType,
+    notes: '',
+    location: 'Central Park',
+    latitude: 49.19,
+    longitude: -122.83,
+    emergency: false,
+    upvotes: 0,
+    downvotes: 0,
+    created_at: createdAt,
+    updated_at: createdAt,
+    ...overrides,
+  };
+}
+
+describe('dashboard analytics', () => {
+  it('builds live KPI metrics from real report and alert data', () => {
+    const vibes = [
+      report(1, VibeType.Safe, '2026-08-03T10:00:00.000Z', { user_id: 'me' }),
+      report(2, VibeType.Calm, '2026-08-02T10:00:00.000Z', { user_id: 'me' }),
+      report(3, VibeType.Dangerous, '2026-08-01T10:00:00.000Z'),
+      report(4, VibeType.Quiet, '2026-07-01T10:00:00.000Z', { user_id: 'me' }),
+    ];
+    const alerts: SOS[] = [
+      report(5, VibeType.Dangerous, '2026-08-03T11:00:00.000Z', { emergency: true }) as SOS,
+    ];
+
+    expect(buildDashboardMetrics(vibes, alerts, 'me', NOW)).toEqual({
+      reportsToday: 2,
+      weeklyReports: 4,
+      safetyScore: 50,
+      contributors: 3,
+      activeAlerts: 1,
+      monthlyUserReports: 2,
+      monthlyGoal: 4,
+      monthlyGoalProgress: 50,
+    });
+  });
+
+  it('returns seven trend points and keeps empty days nullable', () => {
+    const trend = buildWeeklyTrend([
+      report(1, VibeType.Safe, '2026-08-03T10:00:00.000Z'),
+      report(2, VibeType.Dangerous, '2026-08-03T11:00:00.000Z'),
+    ], NOW, 'en-CA');
+
+    expect(trend).toHaveLength(7);
+    expect(trend.slice(0, 6).every((point) => point.score === null)).toBe(true);
+    expect(trend[6]).toMatchObject({ reports: 2, positive: 1, score: 50 });
+  });
+
+  it('groups recent areas and reports the latest coordinates', () => {
+    const areas = buildAreaSummaries([
+      report(1, VibeType.Safe, '2026-08-01T10:00:00.000Z'),
+      report(2, VibeType.Calm, '2026-08-03T09:00:00.000Z', { latitude: 49.2, longitude: -122.8 }),
+      report(3, VibeType.Dangerous, '2026-08-02T09:00:00.000Z', { location: 'Market Square' }),
+    ], NOW);
+
+    expect(areas[0]).toMatchObject({ label: 'Central Park', reports: 2, safetyScore: 100, latitude: 49.2 });
+    expect(areas[1]).toMatchObject({ label: 'Market Square', reports: 1, safetyScore: 0 });
+  });
+
+  it('prioritizes recent alerts and risky vibes while ignoring stale signals', () => {
+    const attention = buildAttentionItems([
+      report(1, VibeType.Suspicious, '2026-08-03T10:00:00.000Z'),
+      report(2, VibeType.Safe, '2026-08-03T11:00:00.000Z'),
+      report(3, VibeType.Dangerous, '2026-07-30T10:00:00.000Z'),
+    ], [
+      report(4, VibeType.Dangerous, '2026-08-03T11:30:00.000Z', { emergency: true }) as SOS,
+    ], NOW);
+
+    expect(attention.map((item) => item.id)).toEqual([4, 1]);
+    expect(attention[0].type).toBe('alert');
+  });
+
+  it('calculates the current vibe distribution', () => {
+    const distribution = buildVibeDistribution([
+      report(1, VibeType.Safe, '2026-08-03T10:00:00.000Z'),
+      report(2, VibeType.Safe, '2026-08-02T10:00:00.000Z'),
+      report(3, VibeType.Calm, '2026-08-01T10:00:00.000Z'),
+    ], NOW);
+
+    expect(distribution).toEqual([
+      { type: 'safe', count: 2, percentage: 67 },
+      { type: 'calm', count: 1, percentage: 33 },
+    ]);
+  });
+});

--- a/src/lib/dashboardAnalytics.ts
+++ b/src/lib/dashboardAnalytics.ts
@@ -1,0 +1,206 @@
+import type { Report, SOS, Vibe } from '../types';
+
+import { calculateSafetyScore } from './safetyAnalytics';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const POSITIVE_VIBES = new Set(['safe', 'calm', 'quiet']);
+const ATTENTION_VIBES = new Set(['dangerous', 'suspicious', 'crowded']);
+
+export interface DashboardMetrics {
+  reportsToday: number;
+  weeklyReports: number;
+  safetyScore: number | null;
+  contributors: number;
+  activeAlerts: number;
+  monthlyUserReports: number;
+  monthlyGoal: number;
+  monthlyGoalProgress: number;
+}
+
+export interface WeeklyTrendPoint {
+  date: string;
+  label: string;
+  score: number | null;
+  reports: number;
+  positive: number;
+}
+
+export interface VibeDistributionItem {
+  type: string;
+  count: number;
+  percentage: number;
+}
+
+export interface AreaSummary {
+  key: string;
+  label: string;
+  reports: number;
+  safetyScore: number;
+  lastUpdated: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface AttentionItem {
+  id: number;
+  type: 'alert' | 'report';
+  vibeType: string;
+  location: string;
+  createdAt: string;
+  notes?: string;
+  latitude: number;
+  longitude: number;
+}
+
+function isValidDate(date: Date): boolean {
+  return !Number.isNaN(date.getTime());
+}
+
+function reportTime(report: Report): number {
+  const date = new Date(report.created_at);
+  return isValidDate(date) ? date.getTime() : 0;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function reportsSince(reports: Report[], from: number, to: number): Report[] {
+  return reports.filter((report) => {
+    const timestamp = reportTime(report);
+    return timestamp >= from && timestamp < to;
+  });
+}
+
+export function buildDashboardMetrics(
+  vibes: Vibe[],
+  sosAlerts: SOS[],
+  userId?: string,
+  now: Date = new Date(),
+  monthlyGoal = 4,
+): DashboardMetrics {
+  const allReports: Report[] = [...vibes, ...sosAlerts];
+  const nowTime = now.getTime();
+  const todayStart = startOfLocalDay(now).getTime();
+  const weekStart = nowTime - (7 * DAY_MS);
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
+
+  const reportsToday = reportsSince(allReports, todayStart, nowTime + 1);
+  const weeklyReports = reportsSince(allReports, weekStart, nowTime + 1);
+  const activeAlerts = reportsSince(sosAlerts, nowTime - DAY_MS, nowTime + 1);
+  const monthlyUserReports = vibes.filter((report) => (
+    report.user_id === userId
+    && reportTime(report) >= monthStart
+    && reportTime(report) <= nowTime
+  ));
+
+  return {
+    reportsToday: reportsToday.length,
+    weeklyReports: weeklyReports.length,
+    safetyScore: weeklyReports.length > 0 ? calculateSafetyScore(weeklyReports) : null,
+    contributors: new Set(weeklyReports.map((report) => report.user_id).filter(Boolean)).size,
+    activeAlerts: activeAlerts.length,
+    monthlyUserReports: monthlyUserReports.length,
+    monthlyGoal,
+    monthlyGoalProgress: Math.min(100, Math.round((monthlyUserReports.length / monthlyGoal) * 100)),
+  };
+}
+
+export function buildWeeklyTrend(
+  reports: Report[],
+  now: Date = new Date(),
+  locale = 'en-CA',
+): WeeklyTrendPoint[] {
+  const today = startOfLocalDay(now);
+
+  return Array.from({ length: 7 }, (_, index) => {
+    const dayStart = new Date(today.getTime() - ((6 - index) * DAY_MS));
+    const dayEnd = new Date(dayStart.getTime() + DAY_MS);
+    const dailyReports = reportsSince(reports, dayStart.getTime(), dayEnd.getTime());
+    const positive = dailyReports.filter((report) => POSITIVE_VIBES.has(report.vibe_type)).length;
+
+    return {
+      date: dayStart.toISOString(),
+      label: dayStart.toLocaleDateString(locale, { weekday: 'short' }).slice(0, 2),
+      score: dailyReports.length > 0 ? calculateSafetyScore(dailyReports) : null,
+      reports: dailyReports.length,
+      positive,
+    };
+  });
+}
+
+export function buildVibeDistribution(reports: Report[], now: Date = new Date()): VibeDistributionItem[] {
+  const monthReports = reportsSince(reports, now.getTime() - (30 * DAY_MS), now.getTime() + 1);
+  const counts = new Map<string, number>();
+
+  monthReports.forEach((report) => {
+    counts.set(report.vibe_type, (counts.get(report.vibe_type) ?? 0) + 1);
+  });
+
+  return Array.from(counts.entries())
+    .map(([type, count]) => ({
+      type,
+      count,
+      percentage: monthReports.length > 0 ? Math.round((count / monthReports.length) * 100) : 0,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 4);
+}
+
+export function buildAreaSummaries(reports: Report[], now: Date = new Date()): AreaSummary[] {
+  const recentReports = reportsSince(reports, now.getTime() - (30 * DAY_MS), now.getTime() + 1);
+  const groups = new Map<string, Report[]>();
+
+  recentReports.forEach((report) => {
+    const location = report.location?.trim();
+    const key = location || `${report.latitude.toFixed(2)},${report.longitude.toFixed(2)}`;
+    groups.set(key, [...(groups.get(key) ?? []), report]);
+  });
+
+  return Array.from(groups.entries())
+    .map(([key, areaReports]) => {
+      const sorted = [...areaReports].sort((a, b) => reportTime(b) - reportTime(a));
+      const latest = sorted[0];
+
+      return {
+        key,
+        label: latest.location?.trim() || key,
+        reports: areaReports.length,
+        safetyScore: calculateSafetyScore(areaReports),
+        lastUpdated: latest.created_at,
+        latitude: latest.latitude,
+        longitude: latest.longitude,
+      };
+    })
+    .sort((a, b) => b.reports - a.reports || new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime())
+    .slice(0, 3);
+}
+
+export function buildAttentionItems(
+  vibes: Vibe[],
+  sosAlerts: SOS[],
+  now: Date = new Date(),
+): AttentionItem[] {
+  const from = now.getTime() - (48 * 60 * 60 * 1000);
+  const items: AttentionItem[] = [
+    ...sosAlerts.map((report) => ({ report, type: 'alert' as const })),
+    ...vibes
+      .filter((report) => ATTENTION_VIBES.has(report.vibe_type))
+      .map((report) => ({ report, type: 'report' as const })),
+  ]
+    .filter(({ report }) => reportTime(report) >= from && reportTime(report) <= now.getTime())
+    .sort((a, b) => reportTime(b.report) - reportTime(a.report))
+    .slice(0, 3)
+    .map(({ report, type }) => ({
+      id: report.id,
+      type,
+      vibeType: report.vibe_type,
+      location: report.location?.trim() || `${report.latitude.toFixed(2)}, ${report.longitude.toFixed(2)}`,
+      createdAt: report.created_at,
+      notes: report.notes,
+      latitude: report.latitude,
+      longitude: report.longitude,
+    }));
+
+  return items;
+}

--- a/src/lib/displayFormatters.ts
+++ b/src/lib/displayFormatters.ts
@@ -1,0 +1,21 @@
+export const formatNumber = (value: number | string): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return String(value);
+};
+
+export const formatTemperature = (temperature: number): string =>
+  `${formatNumber(Math.round(temperature))}°`;
+
+export const formatPercentage = (value: number): string =>
+  `${formatNumber(Math.round(value))}%`;
+
+export const formatDistance = (distance: number, unit: 'km' | 'm' = 'km'): string => {
+  if (unit === 'm' && distance < 1000) {
+    return `${formatNumber(Math.round(distance))}m`;
+  }
+
+  return `${formatNumber((distance / 1000).toFixed(1))}km`;
+};

--- a/src/lib/i18nUtils.ts
+++ b/src/lib/i18nUtils.ts
@@ -6,7 +6,6 @@ export class DateTimeFormatter {
     // Map language codes to locale codes
     const localeMap: { [key: string]: string } = {
       'en': 'en-US',
-      'ar': 'ar-SA',
       // Add more language-to-locale mappings as needed
     };
 
@@ -84,7 +83,6 @@ export class NumberFormatter {
   private static getLocale(language: string = i18n.language): string {
     const localeMap: { [key: string]: string } = {
       'en': 'en-US',
-      'ar': 'ar-SA',
     };
 
     return localeMap[language] || language;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -115,13 +115,35 @@
     }
   },
   "tabs": {
+    "dashboard": "Overview",
     "map": "Map",
     "reports": "Reports",
     "hub": "Hub",
     "guardian": "Guardian",
     "community": "Community",
     "profile": "Profile",
-    "settings": "Settings"
+    "settings": "Settings",
+    "more": "More"
+  },
+  "dashboard": {
+    "noData": "Waiting for data",
+    "neighbour": "Neighbour",
+    "liveOverview": "Live community overview",
+    "greetings": { "morning": "Good morning", "afternoon": "Good afternoon", "evening": "Good evening" },
+    "locationReady": "Your local safety pulse is ready.",
+    "locationUnavailable": "Enable location to see a more relevant community pulse.",
+    "openHub": "Open hub",
+    "newReport": "New report",
+    "overall": { "title": "Community pulse", "period": "Live overview" },
+    "metrics": { "reportsToday": "Reports today", "activeAlerts": "Active alerts", "safety": "Safety score", "contributors": "Contributors", "weeklyReports": "This week" },
+    "trend": { "title": "Weekly safety trend", "subtitle": "The last seven days", "chartLabel": "Weekly community safety chart", "empty": "Your trend will appear after the first report." },
+    "progress": { "title": "Monthly pulse", "subtitle": "Your community contribution", "reports": "reports shared", "empty": "No vibe reports this month." },
+    "viewCommunity": "View community",
+    "goals": { "title": "Monthly goals", "complete": "complete", "firstPulse": "Share your first pulse", "stayActive": "Share two local updates", "communityVoice": "Reach four monthly reports", "trustedProfile": "Complete profile verification" },
+    "attention": { "title": "Needs attention", "subtitle": "Recent alerts and safety signals", "emergency": "Emergency alert", "clearTitle": "Everything looks clear", "clearSubtitle": "No urgent signals nearby.", "add": "Add a community report" },
+    "viewAll": "View all",
+    "areas": { "title": "Recent areas", "subtitle": "Safety pulse by location", "reports": "reports", "updated": "Updated", "emptyTitle": "Create the first area pulse", "emptySubtitle": "Your reported locations will appear here." },
+    "openMap": "Open map"
   },
   "app": {
     "appName": "HyperApp",

--- a/src/services/auth.profile-recovery.test.ts
+++ b/src/services/auth.profile-recovery.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  updateAuthUser: vi.fn(),
+  updateProfile: vi.fn(),
+  updateEq: vi.fn(),
+  updateSelect: vi.fn(),
+  upsertProfile: vi.fn(),
+  upsertSelect: vi.fn(),
+}));
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: mocks.getUser,
+      updateUser: mocks.updateAuthUser,
+    },
+    from: vi.fn(() => ({
+      update: mocks.updateProfile,
+      upsert: mocks.upsertProfile,
+    })),
+  },
+}));
+
+import { authService } from './auth';
+
+describe('profile save recovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const authUser = {
+      id: 'user-a',
+      email: 'user@example.com',
+      user_metadata: { username: 'existing-user' },
+    };
+
+    mocks.getUser.mockResolvedValue({ data: { user: authUser }, error: null });
+    mocks.updateAuthUser.mockResolvedValue({
+      data: { user: { ...authUser, user_metadata: { ...authUser.user_metadata, first_name: 'Amina' } } },
+      error: null,
+    });
+    mocks.updateSelect.mockResolvedValue({ data: [], error: null });
+    mocks.updateEq.mockReturnValue({ select: mocks.updateSelect });
+    mocks.updateProfile.mockReturnValue({ eq: mocks.updateEq });
+    mocks.upsertSelect.mockResolvedValue({
+      data: null,
+      error: { code: '42501', message: 'row-level security policy blocked the write' },
+    });
+    mocks.upsertProfile.mockReturnValue({ select: mocks.upsertSelect });
+  });
+
+  it('preserves personal changes in Auth metadata when a missing public profile cannot be repaired', async () => {
+    const result = await authService.updateUserProfile('user-a', { first_name: 'Amina' });
+
+    expect(mocks.updateAuthUser).toHaveBeenCalledWith({ data: { first_name: 'Amina' } });
+    expect(mocks.upsertProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'user-a', first_name: 'Amina' }),
+      { onConflict: 'user_id' },
+    );
+    expect(result).toEqual(expect.objectContaining({
+      data: { first_name: 'Amina' },
+      error: null,
+    }));
+  });
+});

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -4,9 +4,134 @@ import { AuthResponse, User } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
 import type { User as AppUser } from '../types';
 
-// Supabase configuration
-const supabaseUrl = 'https://nqwejzbayquzsvcodunl.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5xd2VqemJheXF1enN2Y29kdW5sIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgzOTA0MjAsImV4cCI6MjA3Mzk2NjQyMH0.01yifC-tfEbBHD5u315fpb_nZrqMZCbma_UrMacMb78';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+type ProfileQueryError = {
+  code: 'PROFILE_NOT_FOUND' | 'PROFILE_DUPLICATE';
+  message: string;
+  details: string;
+};
+
+type ProfileQueryResult<T> = {
+  data: T | null;
+  error: ProfileQueryError | null;
+};
+
+const PROFILE_WRITE_FIELDS: ReadonlyArray<keyof AppUser> = [
+  'email',
+  'username',
+  'first_name',
+  'last_name',
+  'phone',
+  'profile_picture_url',
+  'location',
+  'interests',
+  'reputation',
+  'language',
+  'profile_completed_at',
+  'onboarding_completed',
+  'verification_level',
+  'verified_at',
+  'verification_badge_earned_at',
+  'email_verified',
+];
+
+export const sanitizeProfileUpdates = (updates: Partial<AppUser>): Partial<AppUser> =>
+  PROFILE_WRITE_FIELDS.reduce<Partial<AppUser>>((payload, field) => {
+    if (updates[field] !== undefined) {
+      (payload as Record<string, unknown>)[field] = updates[field];
+    }
+    return payload;
+  }, {});
+
+const AUTH_METADATA_FIELDS: ReadonlyArray<keyof AppUser> = [
+  'username',
+  'first_name',
+  'last_name',
+  'phone',
+  'profile_picture_url',
+  'location',
+  'interests',
+  'language',
+  'profile_completed_at',
+  'onboarding_completed',
+];
+
+export const buildAuthProfileMetadata = (updates: Partial<AppUser>): Partial<AppUser> =>
+  AUTH_METADATA_FIELDS.reduce<Partial<AppUser>>((metadata, field) => {
+    if (updates[field] !== undefined) {
+      (metadata as Record<string, unknown>)[field] = updates[field];
+    }
+    return metadata;
+  }, {});
+
+export const buildProfileUpsertPayload = (
+  userId: string,
+  updates: Partial<AppUser>,
+  authIdentity: { email?: string | null; username?: string | null },
+) => ({
+  user_id: userId,
+  username: authIdentity.username || authIdentity.email?.split('@')[0] || 'User',
+  email: authIdentity.email || '',
+  reputation: 0,
+  language: 'en',
+  ...sanitizeProfileUpdates(updates),
+});
+
+/**
+ * PostgREST's single-row coercion returns the opaque PGRST116 message when a
+ * query finds either zero rows or more than one row. Keep the response as an
+ * array and validate it here so callers receive an actionable error instead.
+ */
+export const resolveProfileRow = <T>(
+  rows: T[] | null | undefined,
+  operation: 'load' | 'create' | 'update',
+  allowMissing = false,
+): ProfileQueryResult<T> => {
+  const rowCount = rows?.length ?? 0;
+
+  if (rowCount === 0) {
+    if (allowMissing) {
+      return { data: null, error: null };
+    }
+
+    return {
+      data: null,
+      error: {
+        code: 'PROFILE_NOT_FOUND',
+        message: `Profile ${operation} failed because no accessible profile record was found.`,
+        details: 'The users query returned zero rows. The profile may be missing or blocked by row-level security.',
+      },
+    };
+  }
+
+  if (rowCount > 1) {
+    return {
+      data: null,
+      error: {
+        code: 'PROFILE_DUPLICATE',
+        message: 'This account has duplicate profile records. Please contact support so the account data can be repaired safely.',
+        details: `Expected one users row but received ${rowCount}.`,
+      },
+    };
+  }
+
+  return { data: rows![0], error: null };
+};
+
+export const mergeAuthIdentity = (
+  authUser: Pick<User, 'id' | 'email' | 'email_confirmed_at'>,
+  profile: Partial<AppUser>,
+): AppUser => ({
+  ...profile,
+  // Never allow a primary key from the public profile table to replace the
+  // auth ID used in every users.user_id filter.
+  id: authUser.id,
+  email: authUser.email || profile.email || '',
+  email_verified: Boolean(authUser.email_confirmed_at),
+  email_verified_at: authUser.email_confirmed_at,
+});
 
 class AuthService {
   // Authentication methods
@@ -186,39 +311,119 @@ class AuthService {
 
   // User profile methods
   async createUserProfile(userId: string, profileData: Partial<AppUser>): Promise<any> {
-    const { data, error } = await supabase
+    const payload = buildProfileUpsertPayload(userId, profileData, {
+      email: profileData.email,
+      username: profileData.username,
+    });
+    const { data: rows, error } = await supabase
       .from('users')
-      .insert([{
-        user_id: userId,
-        ...profileData,
-        reputation: 0,
-        language: 'en',
-      }])
-      .select()
-      .single();
+      .upsert(payload, { onConflict: 'user_id' })
+      .select();
 
-    return { data, error };
+    if (error) {
+      return { data: null, error };
+    }
+
+    return resolveProfileRow(rows, 'create');
   }
 
   async getUserProfile(userId: string): Promise<any> {
-    const { data, error } = await supabase
+    const { data: rows, error } = await supabase
       .from('users')
       .select('*')
       .eq('user_id', userId)
-      .maybeSingle();
+      .limit(2);
 
-    return { data, error };
+    if (error) {
+      return { data: null, error };
+    }
+
+    return resolveProfileRow(rows, 'load', true);
   }
 
   async updateUserProfile(userId: string, updates: Partial<AppUser>): Promise<any> {
-    const { data, error } = await supabase
-      .from('users')
-      .update(updates)
-      .eq('user_id', userId)
-      .select()
-      .single();
+    const { data: authData, error: authLookupError } = await supabase.auth.getUser();
+    if (authLookupError) {
+      return { data: null, error: authLookupError };
+    }
 
-    return { data, error };
+    let authenticatedUser = authData.user;
+    if (!authenticatedUser || authenticatedUser.id !== userId) {
+      return {
+        data: null,
+        error: {
+          code: 'PROFILE_NOT_FOUND',
+          message: 'The signed-in account does not match the profile being updated.',
+          details: 'The Auth user ID did not match users.user_id.',
+        },
+      };
+    }
+
+    if (updates.email) {
+      if (authenticatedUser.email && authenticatedUser.email !== updates.email) {
+        const { error: authEmailError } = await supabase.auth.updateUser({ email: updates.email });
+        if (authEmailError) {
+          return { data: null, error: authEmailError };
+        }
+      }
+    }
+
+    const safeUpdates = sanitizeProfileUpdates(updates);
+    const authMetadata = buildAuthProfileMetadata(safeUpdates);
+    let metadataSaved = Object.keys(authMetadata).length === 0;
+    let metadataError: unknown = null;
+
+    if (!metadataSaved) {
+      const { data: updatedAuthData, error: authMetadataError } = await supabase.auth.updateUser({
+        data: authMetadata,
+      });
+      metadataSaved = !authMetadataError;
+      metadataError = authMetadataError;
+      authenticatedUser = updatedAuthData.user || authenticatedUser;
+    }
+
+    const { data: rows, error } = await supabase
+      .from('users')
+      .update(safeUpdates)
+      .eq('user_id', userId)
+      .select();
+
+    if (error) {
+      if (metadataSaved) {
+        console.warn('Public profile update failed; changes were preserved in Auth metadata.', error);
+        return { data: safeUpdates, error: null, warning: error };
+      }
+      return { data: null, error };
+    }
+
+    const updateResult = resolveProfileRow(rows, 'update', true);
+    if (updateResult.data || updateResult.error) {
+      return updateResult;
+    }
+
+    // Older accounts can have a valid Auth identity but no public.users row.
+    // Repair that state during the save instead of asking the user to sign out.
+    const repairPayload = buildProfileUpsertPayload(userId, safeUpdates, {
+      email: authenticatedUser.email,
+      username: authenticatedUser.user_metadata?.username || authenticatedUser.user_metadata?.display_name,
+    });
+    const { data: repairedRows, error: repairError } = await supabase
+      .from('users')
+      .upsert(repairPayload, { onConflict: 'user_id' })
+      .select();
+
+    if (repairError) {
+      if (metadataSaved) {
+        console.warn('Public profile repair failed; changes were preserved in Auth metadata.', repairError);
+        return { data: safeUpdates, error: null, warning: repairError };
+      }
+      if (metadataError) {
+        console.error('Auth metadata backup also failed.', metadataError);
+      }
+      return { data: null, error: repairError };
+    }
+
+    return resolveProfileRow(repairedRows, 'update');
   }
 
 
@@ -229,10 +434,9 @@ class AuthService {
       // First check if profile exists
       const { data: profile, error } = await this.getUserProfile(authUser.id);
 
-      if (error && error.code !== 'PGRST116') {
-        // PGRST116 is "not found" error, which is expected for new users
-        console.warn('Profile fetch error:', error);
-        // Continue to create profile instead of throwing
+      if (error) {
+        console.error('Profile fetch error:', error);
+        throw new Error(error.message || 'The profile could not be loaded.');
       }
 
       // Check for pending profile data from signup
@@ -252,20 +456,18 @@ class AuthService {
         // Profile exists, merge with any pending data and update if needed
         console.log('Found existing profile for user:', authUser.id);
 
-        let mergedProfile = {
-          id: authUser.id,
-          email: authUser.email!,
-          email_verified: authUser.email_confirmed_at ? true : false,
-          email_verified_at: authUser.email_confirmed_at,
-          ...profile,
-        };
+        const metadataProfile = sanitizeProfileUpdates(authUser.user_metadata as Partial<AppUser>);
+        let mergedProfile = mergeAuthIdentity(authUser, { ...profile, ...metadataProfile });
 
         // If we have pending profile data and the profile is incomplete, update it
         if (pendingProfile && !profile.first_name) {
           console.log('Updating existing profile with pending data');
           try {
-            await this.updateUserProfile(authUser.id, pendingProfile);
-            mergedProfile = { ...mergedProfile, ...pendingProfile };
+            const pendingUpdate = await this.updateUserProfile(authUser.id, pendingProfile);
+            if (pendingUpdate.error || !pendingUpdate.data) {
+              throw new Error(pendingUpdate.error?.message || 'Pending profile data could not be saved.');
+            }
+            mergedProfile = mergeAuthIdentity(authUser, { ...mergedProfile, ...pendingProfile });
             // Clear the pending data
             if (typeof localStorage !== 'undefined') {
               localStorage.removeItem(pendingProfileKey);
@@ -285,12 +487,14 @@ class AuthService {
                         authUser.email?.split('@')[0] ||
                         'User';
 
+        const metadataProfile = sanitizeProfileUpdates(authUser.user_metadata as Partial<AppUser>);
         const profileData = {
           username,
           email: authUser.email,
           reputation: 0,
           language: authUser.user_metadata?.language || 'en',
           email_verified: authUser.email_confirmed_at ? true : false,
+          ...metadataProfile,
         };
 
         const { data: newProfile, error: createError } = await this.createUserProfile(authUser.id, profileData);
@@ -307,22 +511,18 @@ class AuthService {
             language: 'en',
             email_verified: authUser.email_confirmed_at ? true : false,
             email_verified_at: authUser.email_confirmed_at,
+            ...metadataProfile,
           };
           return minimalProfile;
         }
 
         console.log('Profile created successfully');
-        return {
-          id: authUser.id,
-          email: authUser.email!,
-          email_verified: authUser.email_confirmed_at ? true : false,
-          email_verified_at: authUser.email_confirmed_at,
-          ...newProfile,
-        };
+        return mergeAuthIdentity(authUser, newProfile);
       }
     } catch (error) {
       console.error('Profile sync failed:', error);
       // Return minimal user object to prevent auth failure
+      const metadataProfile = sanitizeProfileUpdates(authUser.user_metadata as Partial<AppUser>);
       const fallbackUser: AppUser = {
         id: authUser.id,
         email: authUser.email!,
@@ -331,6 +531,7 @@ class AuthService {
         language: 'en',
         email_verified: authUser.email_confirmed_at ? true : false,
         email_verified_at: authUser.email_confirmed_at,
+        ...metadataProfile,
       };
       console.log('Using fallback user profile');
       return fallbackUser;
@@ -339,7 +540,7 @@ class AuthService {
 
   // Auth state listener
   onAuthStateChange(callback: (user: User | null) => void) {
-    return supabase.auth.onAuthStateChange((event, session) => {
+    return supabase.auth.onAuthStateChange((_event, session) => {
       callback(session?.user || null);
     });
   }

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -110,7 +110,7 @@ class EventService {
       }
 
       // Call Supabase Edge Function to fetch Ticketmaster events (solves CORS issues)
-      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://nqwejzbayquzsvcodunl.supabase.co';
+      const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
       const functionUrl = `${supabaseUrl}/functions/v1/fetch-ticketmaster-events`;
 
       console.log('🎫 Calling Supabase Edge Function for Ticketmaster events with params:', { latitude, longitude, radius });

--- a/src/services/userLocationService.ts
+++ b/src/services/userLocationService.ts
@@ -254,13 +254,24 @@ class UserLocationService {
     try {
       console.log('🔄 Updating location sharing preference:', { userId, enabled });
 
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from('users')
         .update({ location_sharing: enabled })
-        .eq('user_id', userId);
+        .eq('user_id', userId)
+        .select('user_id');
 
       if (error) {
         console.error('❌ Error updating location sharing preference:', error);
+        return false;
+      }
+
+      if (!data || data.length !== 1) {
+        console.error(
+          'Location sharing preference was not saved:',
+          data?.length === 0
+            ? 'no accessible profile record was found'
+            : 'duplicate profile records were found',
+        );
         return false;
       }
 

--- a/src/styles/appShell.css
+++ b/src/styles/appShell.css
@@ -1,0 +1,733 @@
+:root {
+  --app-sidebar-width: 272px;
+  --app-mobile-header-height: 62px;
+  --app-mobile-nav-height: 78px;
+  --app-shell-border: rgba(15, 23, 42, 0.1);
+  --app-overlay-backdrop: rgba(15, 18, 24, 0.62);
+  --app-z-content: 1;
+  --app-z-map-control: 40;
+  --app-z-sidebar: 100;
+  --app-z-mobile-nav: 200;
+  --app-z-mobile-header: 210;
+  --app-z-popover: 900;
+  --app-z-modal: 2000;
+  --app-z-toast: 3000;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  min-width: 0;
+  min-height: 100%;
+}
+
+body {
+  overscroll-behavior: none;
+}
+
+button,
+[role='button'] {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.app-modal-overlay {
+  box-sizing: border-box !important;
+  z-index: var(--app-z-modal) !important;
+}
+
+.app-modal-dialog {
+  box-sizing: border-box !important;
+  width: calc(100% - 32px) !important;
+  min-width: 0 !important;
+  max-width: min(500px, calc(100vw - 32px)) !important;
+  max-height: calc(100dvh - 32px) !important;
+  overflow-wrap: anywhere;
+}
+
+.app-layout {
+  width: 100%;
+  height: 100dvh;
+  min-height: 100dvh;
+  overflow: hidden;
+}
+
+.app-main {
+  width: auto;
+  min-width: 0;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.app-content-desktop {
+  min-width: 0;
+  min-height: 0;
+  overscroll-behavior: contain;
+}
+
+/* Dashboard-aligned desktop sidebar */
+.app-sidebar {
+  width: var(--app-sidebar-width) !important;
+  padding: 20px 16px 16px !important;
+  overflow: hidden !important;
+  color: #f8fafc;
+  background:
+    radial-gradient(circle at 16% 4%, rgba(255, 255, 255, 0.09), transparent 22%),
+    linear-gradient(180deg, #15171c 0%, #101216 54%, #0d0f13 100%) !important;
+  border-right: 1px solid rgba(255, 255, 255, 0.08) !important;
+  box-shadow: 18px 0 54px rgba(15, 23, 42, 0.14) !important;
+  z-index: var(--app-z-sidebar) !important;
+}
+
+.app-sidebar::after {
+  content: '';
+  position: absolute;
+  inset: auto -70px -80px auto;
+  width: 190px;
+  height: 190px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 46% 54% 64% 36%;
+  transform: rotate(-24deg);
+  pointer-events: none;
+}
+
+.app-sidebar__top,
+.app-sidebar__brand,
+.app-sidebar__status,
+.app-sidebar__nav-item,
+.app-sidebar__identity,
+.app-sidebar__create,
+.app-mobile-header,
+.app-mobile-header__brand {
+  display: flex;
+  align-items: center;
+}
+
+.app-sidebar__top {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.app-sidebar__brand {
+  min-width: 0;
+  gap: 11px;
+}
+
+.app-sidebar__brand-mark,
+.app-mobile-header__mark {
+  width: 38px;
+  height: 38px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 13px;
+  background: #f7f7f5;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+}
+
+.app-sidebar__brand-mark > span,
+.app-mobile-header__mark > span {
+  width: 15px;
+  height: 15px;
+  background: #111318;
+  clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+}
+
+.app-sidebar__brand > div,
+.app-mobile-header__brand > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-sidebar__brand strong {
+  color: #fff;
+  font-size: 17px;
+  font-weight: 750;
+  line-height: 1.1;
+  letter-spacing: -0.035em;
+}
+
+.app-sidebar__brand div > span {
+  margin-top: 3px;
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.app-sidebar__status {
+  width: fit-content;
+  gap: 8px;
+  margin: 27px 8px 14px;
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.app-sidebar__status > span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #26c991;
+  box-shadow: 0 0 0 5px rgba(38, 201, 145, 0.1);
+}
+
+.app-sidebar__nav {
+  min-height: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.app-sidebar__nav::-webkit-scrollbar {
+  display: none;
+}
+
+.app-sidebar__nav-item {
+  width: 100%;
+  min-height: 48px;
+  gap: 12px;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  border-radius: 15px;
+  color: rgba(255, 255, 255, 0.62);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  text-align: start;
+  cursor: pointer;
+  transition: color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.app-sidebar__nav-item:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateX(2px);
+}
+
+.app-sidebar__nav-item.is-active {
+  color: #111318;
+  background: #f4f4f1;
+  border-color: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 13px 28px rgba(0, 0, 0, 0.22);
+}
+
+.app-sidebar__nav-icon {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  color: rgba(255, 255, 255, 0.42);
+}
+
+.app-sidebar__nav-item.is-active .app-sidebar__nav-icon {
+  color: #111318;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+}
+
+.app-sidebar__footer {
+  position: relative;
+  z-index: 1;
+  padding-top: 15px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.app-sidebar__identity {
+  gap: 10px;
+  padding: 0 5px 13px;
+  min-width: 0;
+}
+
+.app-sidebar__identity > span {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 11px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.app-sidebar__identity > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-sidebar__identity strong,
+.app-sidebar__identity small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-sidebar__identity strong {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.app-sidebar__identity small {
+  margin-top: 2px;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 9px;
+}
+
+.app-sidebar__create {
+  width: 100%;
+  min-height: 45px;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.86);
+  border-radius: 14px;
+  color: #111318;
+  background: #f4f4f1;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.22);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.app-sidebar__create:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.28);
+}
+
+/* Notification popover */
+.notification-bell {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.notification-bell__trigger {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(15, 23, 42, 0.09);
+  border-radius: 13px;
+  color: #111318;
+  background: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.notification-bell--dark .notification-bell__trigger {
+  color: rgba(255, 255, 255, 0.76);
+  background: rgba(255, 255, 255, 0.055);
+  border-color: rgba(255, 255, 255, 0.09);
+}
+
+.notification-bell__trigger:hover {
+  transform: translateY(-1px);
+  background: #fff;
+}
+
+.notification-bell--dark .notification-bell__trigger:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.11);
+}
+
+.notification-bell__badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  display: grid;
+  place-items: center;
+  border: 2px solid #fff;
+  border-radius: 999px;
+  color: #fff;
+  background: #ef4444;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.notification-bell--dark .notification-bell__badge {
+  border-color: #15171c;
+}
+
+.notification-panel {
+  position: fixed;
+  z-index: var(--app-z-popover);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--app-shell-border);
+  border-radius: 19px;
+  color: #111318;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 26px 70px rgba(15, 23, 42, 0.2);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.notification-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 15px 16px;
+  border-bottom: 1px solid #e7e8e5;
+  background: #f5f6f3;
+}
+
+.notification-panel__header > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.notification-panel__header strong {
+  font-size: 14px;
+  font-weight: 750;
+}
+
+.notification-panel__header div > span {
+  margin-top: 2px;
+  color: #71717a;
+  font-size: 10px;
+}
+
+.notification-panel__header > span {
+  padding: 5px 8px;
+  border-radius: 999px;
+  color: #047857;
+  background: #d1fae5;
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.notification-panel__list {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.notification-panel__item {
+  width: 100%;
+  min-height: 64px;
+  padding: 11px 14px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  border: 0;
+  border-bottom: 1px solid #eceeeb;
+  color: #111318;
+  background: #fff;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+}
+
+.notification-panel__item:hover,
+.notification-panel__item.is-unread {
+  background: #f7f8f5;
+}
+
+.notification-panel__type {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  color: #475569;
+  background: #eef0ed;
+}
+
+.notification-panel__type--success { color: #047857; background: #d1fae5; }
+.notification-panel__type--warning { color: #b45309; background: #fef3c7; }
+.notification-panel__type--error { color: #b91c1c; background: #fee2e2; }
+
+.notification-panel__copy {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.notification-panel__copy strong,
+.notification-panel__copy > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notification-panel__copy strong { font-size: 12px; font-weight: 700; }
+.notification-panel__copy > span { margin-top: 3px; color: #71717a; font-size: 10px; }
+.notification-panel__time { flex: 0 0 auto; color: #a1a1aa; font-size: 9px; }
+
+.notification-panel__empty {
+  min-height: 180px;
+  padding: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.notification-panel__empty strong { margin-top: 10px; color: #334155; font-size: 13px; }
+.notification-panel__empty span { margin-top: 3px; font-size: 10px; }
+
+/* Mobile shell */
+.app-mobile-header {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: var(--app-z-mobile-header);
+  min-height: calc(var(--app-mobile-header-height) + env(safe-area-inset-top, 0px));
+  justify-content: space-between;
+  gap: 12px;
+  padding: env(safe-area-inset-top, 0px) 14px 0;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 249, 247, 0.94);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.07);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.app-mobile-header__brand { gap: 9px; min-width: 0; }
+.app-mobile-header__mark { width: 34px; height: 34px; border-color: rgba(15, 23, 42, 0.08); box-shadow: none; }
+.app-mobile-header__mark > span { width: 13px; height: 13px; }
+.app-mobile-header__brand strong { color: #111318; font-size: 14px; font-weight: 800; letter-spacing: -0.03em; }
+.app-mobile-header__brand small { margin-top: 1px; color: #71717a; font-size: 9px; }
+
+.tab-navigation {
+  position: fixed !important;
+  inset: auto 0 0 !important;
+  z-index: var(--app-z-mobile-nav) !important;
+  box-sizing: border-box;
+  width: 100%;
+  height: calc(var(--app-mobile-nav-height) + env(safe-area-inset-bottom, 0px)) !important;
+  padding: 7px 8px env(safe-area-inset-bottom, 0px) !important;
+  display: flex;
+  align-items: center;
+  overflow: visible !important;
+  isolation: isolate;
+  border-top: 1px solid rgba(15, 23, 42, 0.09) !important;
+  background: rgba(248, 249, 247, 0.96) !important;
+  box-shadow: 0 -14px 34px rgba(15, 23, 42, 0.08) !important;
+}
+
+.tab-navigation__item,
+.tab-more-toggle {
+  min-width: 0;
+  min-height: 58px;
+  flex: 1;
+  padding: 4px 0 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 3px;
+  border: 0;
+  color: #71717a;
+  background: transparent;
+  font: inherit;
+  font-size: 9px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.tab-navigation__icon,
+.tab-more-toggle__icon {
+  width: 36px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 12px;
+}
+
+.tab-navigation__item.is-active,
+.tab-more-toggle.is-active { color: #111318; }
+
+.tab-navigation__item.is-active .tab-navigation__icon,
+.tab-more-toggle.is-active .tab-more-toggle__icon {
+  border-color: rgba(15, 23, 42, 0.11);
+  background: #fff;
+  box-shadow: 0 7px 16px rgba(15, 23, 42, 0.08);
+}
+
+.tab-navigation__create {
+  width: 46px;
+  height: 46px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  margin: 0 3px 7px;
+  border: 1px solid #111318;
+  border-radius: 15px;
+  color: #fff;
+  background: #111318;
+  box-shadow: 0 12px 24px rgba(17, 19, 24, 0.22);
+  cursor: pointer;
+}
+
+.tab-more-menu {
+  z-index: calc(var(--app-z-mobile-nav) + 1);
+  bottom: calc(100% + 8px) !important;
+  max-height: min(280px, calc(100dvh - var(--app-mobile-header-height) - var(--app-mobile-nav-height) - 30px));
+  overflow-y: auto;
+}
+
+/* Content sizing and overlay containment */
+.map-view-shell,
+.app-content-shell--map {
+  isolation: isolate;
+}
+
+.map-view-shell {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  overflow: hidden;
+  border-radius: 22px;
+}
+
+.leaflet-container { z-index: 0; }
+.modern-map-control-button,
+.location-search-button,
+.vibe-legend { z-index: var(--app-z-map-control) !important; }
+.safety-particle-overlay { z-index: 20 !important; }
+
+.page-view {
+  width: 100% !important;
+  max-width: 920px !important;
+  min-height: 100% !important;
+  border: 1px solid #dfe1dd !important;
+  border-radius: 25px;
+  background: rgba(239, 240, 237, 0.88) !important;
+  box-shadow: 0 22px 60px rgba(15, 23, 42, 0.09);
+}
+
+.page-view__header {
+  top: 0 !important;
+  z-index: 20 !important;
+  border-radius: 25px 25px 0 0;
+  background: rgba(248, 249, 247, 0.94) !important;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.settings-password-input {
+  width: 100%;
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 9px;
+  outline: none;
+  color: #111827;
+  background: #f9fafb;
+  font: inherit;
+  font-size: 14px;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.settings-password-input::placeholder { color: #9ca3af; }
+
+.settings-password-input:focus {
+  border-color: #64748b;
+  background: #fff;
+  box-shadow: 0 0 0 3px rgba(100, 116, 139, 0.13);
+}
+
+[role='dialog'] {
+  max-width: 100vw;
+  max-height: 100dvh;
+}
+
+@media (min-width: 1024px) {
+  .app-main {
+    width: calc(100% - var(--app-sidebar-width));
+    margin-left: var(--app-sidebar-width) !important;
+    margin-right: 0 !important;
+  }
+
+  .app-content-desktop {
+    height: 100dvh;
+    padding: clamp(16px, 1.8vw, 26px);
+  }
+
+  [dir='rtl'] .app-main {
+    margin-right: var(--app-sidebar-width) !important;
+    margin-left: 0 !important;
+  }
+
+  [dir='rtl'] .app-sidebar__nav-item:hover { transform: translateX(-2px); }
+}
+
+@media (max-width: 1023px) {
+  .app-main { width: 100%; margin: 0 !important; }
+
+  .app-content-desktop {
+    height: 100dvh;
+    padding:
+      calc(var(--app-mobile-header-height) + env(safe-area-inset-top, 0px) + 12px)
+      12px
+      calc(var(--app-mobile-nav-height) + env(safe-area-inset-bottom, 0px) + 14px);
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-gutter: auto;
+  }
+
+  .app-content-shell--map,
+  .app-content-shell--map > *,
+  .map-view-shell {
+    min-height: calc(
+      100dvh - var(--app-mobile-header-height) - var(--app-mobile-nav-height)
+      - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 26px
+    ) !important;
+    height: calc(
+      100dvh - var(--app-mobile-header-height) - var(--app-mobile-nav-height)
+      - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 26px
+    ) !important;
+  }
+
+  .page-view {
+    max-width: 760px !important;
+    min-height: auto !important;
+    border-radius: 20px;
+  }
+
+  .page-view__header {
+    top: calc(var(--app-mobile-header-height) + env(safe-area-inset-top, 0px)) !important;
+    border-radius: 20px 20px 0 0;
+  }
+}
+
+@media (max-width: 560px) {
+  .app-content-desktop { padding-inline: 8px; }
+  .map-view-shell { border-radius: 16px; }
+  .page-view { border-radius: 16px; border-inline: 0 !important; }
+  .page-view__header { border-radius: 16px 16px 0 0; }
+  .notification-panel { border-radius: 16px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-sidebar__nav-item,
+  .app-sidebar__create,
+  .notification-bell__trigger {
+    transition: none;
+  }
+}

--- a/src/themes.css
+++ b/src/themes.css
@@ -1,39 +1,34 @@
 :root,
 [data-theme="light"],
 [data-theme="dark"] {
-  /* ── Surfaces ── */
-  --bg-base:      #09090b;
-  --bg-surface:   #111318;
-  --bg-elevated:  #1a1d25;
-  --bg-overlay:   rgba(17, 19, 24, 0.97);
-  --glass:        rgba(255, 255, 255, 0.045);
-  --glass-hover:  rgba(255, 255, 255, 0.07);
-  --wire:         rgba(255, 255, 255, 0.07);
-  --wire2:        rgba(255, 255, 255, 0.12);
+  --bg-base:      #f6f7fb;
+  --bg-surface:   #ffffff;
+  --bg-elevated:  #f3f4f8;
+  --bg-overlay:   rgba(255, 255, 255, 0.96);
+  --glass:        rgba(0, 0, 0, 0.035);
+  --glass-hover:  rgba(0, 0, 0, 0.055);
+  --wire:         rgba(0, 0, 0, 0.08);
+  --wire2:        rgba(0, 0, 0, 0.14);
 
-  /* ── Brand ── */
-  --accent:       #00c896;
-  --accent-dim:   rgba(0, 200, 150, 0.12);
-  --accent-glow:  rgba(0, 200, 150, 0.06);
-  --accent-text:  #09090b;
+  --accent:       #00a87d;
+  --accent-dim:   rgba(0, 168, 125, 0.1);
+  --accent-glow:  rgba(0, 168, 125, 0.08);
+  --accent-text:  #ffffff;
 
-  /* ── Text ── */
-  --t1: #f4f4f5;
-  --t2: #a1a1aa;
-  --t3: #52525b;
+  --t1: #0f172a;
+  --t2: #475569;
+  --t3: #64748b;
 
-  /* ── Semantic ── */
-  --vibe-safe:       #00c896;
-  --vibe-calm:       #4f8ef7;
+  --vibe-safe:       #0ea5e9;
+  --vibe-calm:       #3b82f6;
   --vibe-lively:     #f59e0b;
-  --vibe-festive:    #a855f7;
+  --vibe-festive:    #8b5cf6;
   --vibe-crowded:    #ef4444;
   --vibe-suspicious: #f97316;
-  --vibe-dangerous:  #ff3b5c;
+  --vibe-dangerous:  #dc2626;
   --vibe-noisy:      #eab308;
   --vibe-quiet:      #06b6d4;
 
-  /* ── Radius ── */
   --r-xs:  6px;
   --r-sm:  8px;
   --r-md:  12px;
@@ -41,13 +36,11 @@
   --r-xl:  22px;
   --r-2xl: 28px;
 
-  /* ── Shadows ── */
-  --shadow-sm:   0 1px 3px rgba(0,0,0,0.5);
-  --shadow-md:   0 4px 16px rgba(0,0,0,0.4);
-  --shadow-glow: 0 0 24px rgba(0,200,150,0.15);
-  --shadow-card: 0 1px 3px rgba(0,0,0,0.6), 0 0 0 0.5px rgba(255,255,255,0.04) inset;
+  --shadow-sm:   0 1px 3px rgba(15, 23, 42, 0.08);
+  --shadow-md:   0 8px 24px rgba(15, 23, 42, 0.08);
+  --shadow-glow: 0 0 24px rgba(0, 168, 125, 0.12);
+  --shadow-card: 0 1px 3px rgba(15, 23, 42, 0.05), 0 0 0 0.5px rgba(15, 23, 42, 0.04) inset;
 
-  /* ── Legacy aliases ── */
   --bg-primary:   var(--bg-surface);
   --bg-secondary: var(--bg-elevated);
   --bg-tertiary:  var(--bg-base);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,8 +3,6 @@
 interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string
   readonly VITE_SUPABASE_ANON_KEY: string
-  readonly VITE_OPENAI_API_KEY: string
-  readonly VITE_BYTEZ_API_KEY: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## What changed

- Synchronizes the current HyperApp dashboard, responsive app shell, navigation, settings, and authentication improvements from the authoritative local app.
- Adds the dashboard analytics utilities and tests required by the new home view.
- Wires the hosted Hyper AI voice conversation into the dashboard.
- Removes obsolete client-side Bytez/OpenAI key declarations while preserving Supabase Edge Function AI and TTS.

## Root cause

The earlier deployment copied the AI component files but not the dashboard and app-shell runtime files that render them. Cloudflare correctly deployed GitHub `main`, but `main` was not the complete current app.

## Validation

- `npm run build` — passed
- `npm run test:run` with non-secret Supabase test placeholders — 36/36 passed
- Production assets include `DashboardView` and `VoiceChatModal`, including hosted `hyper-ai` / `hyper-tts` calls
- Secret scan — passed