### PR TITLE
Fix hosted voice playback

### DIFF
--- a/src/components/VoiceChatModal.test.tsx
+++ b/src/components/VoiceChatModal.test.tsx
@@ -100,4 +100,21 @@ describe('VoiceChatModal hands-free conversation', () => {
     await waitFor(() => expect(recognition?.start).toHaveBeenCalledTimes(2), { timeout: 2000 });
     expect(screen.getByRole('button', { name: 'End conversation' })).toBeVisible();
   });
+
+  it('unlocks delayed audio from the typed-message user gesture', async () => {
+    mocks.askHyperAi.mockResolvedValue({ answer: 'The voice response is ready.' });
+
+    render(<VoiceChatModal isOpen onClose={vi.fn()} userLocation={null} />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Message Hyper AI' }), {
+      target: { value: 'Tell me what is nearby.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    expect(mocks.unlock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.speak).toHaveBeenCalledWith(
+      'The voice response is ready.',
+      expect.objectContaining({ volume: 1 }),
+    ));
+  });
 });

--- a/src/components/VoiceChatModal.tsx
+++ b/src/components/VoiceChatModal.tsx
@@ -515,6 +515,11 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
       return;
     }
 
+    // This handler runs inside the user's click/submit gesture, which is the
+    // reliable moment to unlock delayed audio on desktop and mobile browsers.
+    if (isTTSEnabled) {
+      ttsService.unlock();
+    }
     setDraft('');
     void processTranscript(cleanedPrompt);
   };

--- a/src/services/tts.test.ts
+++ b/src/services/tts.test.ts
@@ -51,7 +51,8 @@ describe('TTSService', () => {
   });
 
   it('plays hosted neural audio and caches repeated replies', async () => {
-    const audioBlob = new Blob(['mp3-data'], { type: 'audio/mpeg' });
+    // supabase-js preserves binary function responses as octet-stream Blobs.
+    const audioBlob = new Blob(['mp3-data'], { type: 'application/octet-stream' });
     invokeFunction.mockResolvedValue({ data: audioBlob, error: null });
     const browserSpeak = vi.fn();
     Object.defineProperty(window, 'speechSynthesis', {
@@ -76,6 +77,7 @@ describe('TTSService', () => {
     });
     expect(browserSpeak).not.toHaveBeenCalled();
     expect(URL.createObjectURL).toHaveBeenCalledTimes(2);
+    expect((vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob).type).toBe('audio/mpeg');
     expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
   });
 

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -22,6 +22,7 @@ const VOICE_START_TIMEOUT_MS = 5000;
 const HOSTED_TTS_TIMEOUT_MS = 18000;
 const MAX_SPEECH_CHUNK_LENGTH = 220;
 const MAX_AUDIO_CACHE_ENTRIES = 16;
+const BINARY_AUDIO_CONTENT_TYPE = 'application/octet-stream';
 const SILENT_AUDIO_DATA_URI = 'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQQAAAA=';
 type BrowserVoice = ReturnType<typeof window.speechSynthesis.getVoices>[number];
 
@@ -127,17 +128,16 @@ export class TTSService {
     if (!audio) {
       return;
     }
-    audio.muted = true;
+    // The file itself is silent. Keep the element unmuted so iOS/Safari and
+    // desktop autoplay policies register this user gesture for later speech.
+    audio.muted = false;
     audio.src = SILENT_AUDIO_DATA_URI;
     const unlockAttempt = audio.play();
     if (unlockAttempt) {
       void unlockAttempt.then(() => {
         audio.pause();
         audio.currentTime = 0;
-        audio.muted = false;
-      }).catch(() => {
-        audio.muted = false;
-      });
+      }).catch(() => undefined);
     }
   }
 
@@ -193,11 +193,21 @@ export class TTSService {
       if (error) {
         throw new Error(await getFunctionErrorMessage(error as HostedTtsError));
       }
-      if (!(data instanceof Blob) || data.size === 0 || !data.type.startsWith('audio/')) {
+      if (
+        !(data instanceof Blob) ||
+        data.size === 0 ||
+        (!data.type.startsWith('audio/') && data.type !== BINARY_AUDIO_CONTENT_TYPE)
+      ) {
         throw new Error('Hosted voice returned invalid audio.');
       }
 
-      this.audioCache.set(text, data);
+      // Supabase needs an octet-stream response to preserve the binary body.
+      // Restore the real MIME type before handing the object URL to browsers.
+      const audio = data.type === BINARY_AUDIO_CONTENT_TYPE
+        ? new Blob([data], { type: 'audio/mpeg' })
+        : data;
+
+      this.audioCache.set(text, audio);
       while (this.audioCache.size > MAX_AUDIO_CACHE_ENTRIES) {
         const oldestKey = this.audioCache.keys().next().value as string | undefined;
         if (!oldestKey) {
@@ -205,7 +215,7 @@ export class TTSService {
         }
         this.audioCache.delete(oldestKey);
       }
-      return data;
+      return audio;
     } finally {
       if (timeoutId !== undefined) {
         window.clearTimeout(timeoutId);

--- a/supabase/functions/hyper-tts/index.ts
+++ b/supabase/functions/hyper-tts/index.ts
@@ -14,7 +14,11 @@ const jsonHeaders = {
 const audioHeaders = {
   ...corsHeaders,
   'Cache-Control': 'private, max-age=1800',
-  'Content-Type': 'audio/mpeg',
+  // supabase-js currently treats only application/octet-stream and PDFs as
+  // binary responses. Returning audio/mpeg makes it decode the MP3 as text.
+  'Content-Type': 'application/octet-stream',
+  'Content-Disposition': 'inline; filename="hyper-ai.mp3"',
+  'X-Hyper-Audio-Type': 'audio/mpeg',
   'X-Content-Type-Options': 'nosniff',
 };
 const MODEL = '@cf/myshell-ai/melotts';


### PR DESCRIPTION
## What changed

- return Hyper AI MP3 bytes as an octet-stream so supabase-js preserves the binary response
- restore the audio/mpeg MIME type before browser playback
- unlock delayed speech from typed-message and hands-free user gestures on desktop and mobile
- add regression coverage for binary voice responses and typed-message autoplay unlocking

## Root cause

The Supabase Functions client parsed audio/mpeg responses as text because its binary response handling recognizes application/octet-stream. HyperApp then rejected the response and fell back to browser speech, which could also be blocked after the original user activation expired.

## Validation

- 9 project test files passed (37 tests)
- production Vite build passed
- focused voice and hands-free tests passed