### PR TITLE
Fix iPhone voice playback

### DIFF
--- a/src/services/tts.test.ts
+++ b/src/services/tts.test.ts
@@ -1,4 +1,4 @@
-/* global URL, Blob */
+/* global AudioBuffer, AudioBufferSourceNode, AudioContextState, AudioDestinationNode, GainNode, URL, Blob */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { invokeFunction } = vi.hoisted(() => ({
@@ -24,6 +24,7 @@ class TestAudio {
   currentTime = 0;
   onended: (() => void) | null = null;
   onerror: (() => void) | null = null;
+  setAttribute = vi.fn();
   pause = vi.fn();
   play = vi.fn(() => {
     void Promise.resolve().then(() => this.onended?.());
@@ -131,5 +132,69 @@ describe('TTSService', () => {
     expect(speak).toHaveBeenCalledTimes(1);
     expect(speak.mock.calls[0][0].text).toBe('Natural fallback reply.');
     expect(speak.mock.calls[0][0].voice?.name).toContain('Aria');
+  });
+
+  it('uses a user-unlocked Web Audio context for delayed iPhone playback', async () => {
+    const audioBlob = new Blob(['mp3-data'], { type: 'audio/mpeg' });
+    Object.defineProperty(audioBlob, 'arrayBuffer', {
+      configurable: true,
+      value: vi.fn(async () => new ArrayBuffer(8)),
+    });
+    invokeFunction.mockResolvedValue({ data: audioBlob, error: null });
+
+    const sources: Array<{
+      start: ReturnType<typeof vi.fn>;
+      stop: ReturnType<typeof vi.fn>;
+      playbackRate: { value: number };
+    }> = [];
+    const decodeAudioData = vi.fn(async () => ({ duration: 0.1 } as AudioBuffer));
+
+    class TestAudioContext {
+      state: AudioContextState = 'suspended';
+      sampleRate = 44100;
+      destination = {} as AudioDestinationNode;
+      resume = vi.fn(async () => {
+        this.state = 'running';
+      });
+      createBuffer = vi.fn(() => ({} as AudioBuffer));
+      decodeAudioData = decodeAudioData;
+      createGain = vi.fn(() => ({
+        gain: { value: 1 },
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      } as unknown as GainNode));
+      createBufferSource = vi.fn(() => {
+        const source = {
+          buffer: null,
+          playbackRate: { value: 1 },
+          onended: null as (() => void) | null,
+          connect: vi.fn(),
+          disconnect: vi.fn(),
+          start: vi.fn(),
+          stop: vi.fn(),
+        };
+        source.start.mockImplementation(() => {
+          void Promise.resolve().then(() => source.onended?.());
+        });
+        source.stop.mockImplementation(() => source.onended?.());
+        sources.push(source);
+        return source as unknown as AudioBufferSourceNode;
+      });
+    }
+
+    Object.defineProperty(window, 'AudioContext', {
+      configurable: true,
+      value: TestAudioContext,
+    });
+
+    const service = new TTSService();
+    service.unlock();
+    await service.speak('This should play on an iPhone.', { speed: 1.1, volume: 0.8 });
+
+    expect(decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(sources).toHaveLength(2);
+    expect(sources[1].playbackRate.value).toBe(1.1);
+    expect(sources[1].start).toHaveBeenCalledWith(0);
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
   });
 });

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -1,4 +1,4 @@
-/* global HTMLAudioElement, Blob, URL */
+/* global HTMLAudioElement, AudioBufferSourceNode, AudioContext, Blob, URL, Window */
 import { supabase } from '../lib/supabase';
 
 export interface TTSOptions {
@@ -25,6 +25,11 @@ const MAX_AUDIO_CACHE_ENTRIES = 16;
 const BINARY_AUDIO_CONTENT_TYPE = 'application/octet-stream';
 const SILENT_AUDIO_DATA_URI = 'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQQAAAA=';
 type BrowserVoice = ReturnType<typeof window.speechSynthesis.getVoices>[number];
+type AudioContextConstructor = new () => AudioContext;
+
+interface AudioWindow extends Window {
+  webkitAudioContext?: AudioContextConstructor;
+}
 
 function splitForSpeech(text: string): string[] {
   const sentences = text.match(/[^.!?]+[.!?]+|[^.!?]+$/g)?.map((part) => part.trim()).filter(Boolean) || [text];
@@ -106,6 +111,8 @@ export class TTSService {
   private speechSynthesis: typeof window.speechSynthesis | null = null;
   private voicesPromise: Promise<BrowserVoice[]> | null = null;
   private audioElement: HTMLAudioElement | null = null;
+  private audioContext: AudioContext | null = null;
+  private activeAudioSource: AudioBufferSourceNode | null = null;
   private cancelHostedPlayback: (() => void) | null = null;
   private audioCache = new Map<string, Blob>();
   private requestId = 0;
@@ -117,12 +124,30 @@ export class TTSService {
     if (typeof window !== 'undefined' && typeof window.Audio === 'function') {
       this.audioElement = new window.Audio();
       this.audioElement.preload = 'auto';
+      this.audioElement.setAttribute?.('playsinline', '');
+      this.audioElement.setAttribute?.('webkit-playsinline', '');
     }
   }
 
   unlock(): void {
     this.speechSynthesis?.resume();
     void this.speechSynthesis?.getVoices();
+
+    // iOS does not reliably preserve an HTMLMediaElement autoplay grant across
+    // the async AI/TTS round trip. Resume Web Audio during the direct tap and
+    // keep that context available for the delayed hosted response.
+    const context = this.getOrCreateAudioContext();
+    if (context) {
+      try {
+        const source = context.createBufferSource();
+        source.buffer = context.createBuffer(1, 1, context.sampleRate || 44100);
+        source.connect(context.destination);
+        source.start(0);
+        void context.resume().catch(() => undefined);
+      } catch {
+        // The unlocked HTML audio element below remains the compatibility path.
+      }
+    }
 
     const audio = this.audioElement;
     if (!audio) {
@@ -143,6 +168,28 @@ export class TTSService {
 
   async prepare(): Promise<void> {
     await this.loadVoices();
+  }
+
+  private getOrCreateAudioContext(): AudioContext | null {
+    if (this.audioContext) {
+      return this.audioContext;
+    }
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    const audioWindow = window as AudioWindow;
+    const Context = window.AudioContext || audioWindow.webkitAudioContext;
+    if (!Context) {
+      return null;
+    }
+
+    try {
+      this.audioContext = new Context();
+      return this.audioContext;
+    } catch {
+      return null;
+    }
   }
 
   async speak(text: string, options: TTSOptions = {}): Promise<void> {
@@ -223,7 +270,100 @@ export class TTSService {
     }
   }
 
-  private playHostedAudio(blob: Blob, options: TTSOptions, requestId: number): Promise<void> {
+  private async playHostedAudio(blob: Blob, options: TTSOptions, requestId: number): Promise<void> {
+    if (this.audioContext) {
+      try {
+        await this.playHostedAudioWithWebAudio(blob, options, requestId);
+        return;
+      } catch {
+        if (requestId !== this.requestId) {
+          return;
+        }
+        // Decode or Web Audio output can still fail on older webviews. The
+        // unlocked HTML element remains a safe second hosted-audio path.
+      }
+    }
+
+    await this.playHostedAudioWithElement(blob, options, requestId);
+  }
+
+  private async playHostedAudioWithWebAudio(
+    blob: Blob,
+    options: TTSOptions,
+    requestId: number,
+  ): Promise<void> {
+    const context = this.audioContext;
+    if (!context) {
+      throw new Error('Web Audio playback is unavailable on this device.');
+    }
+
+    await context.resume();
+    if (context.state !== 'running') {
+      throw new Error('Web Audio playback is still suspended.');
+    }
+
+    const decodedAudio = await context.decodeAudioData(await blob.arrayBuffer());
+    if (requestId !== this.requestId) {
+      return;
+    }
+
+    const { speed = 1, volume = 1 } = options;
+    const playbackRate = Math.max(0.8, Math.min(1.2, speed));
+    const source = context.createBufferSource();
+    const gain = context.createGain();
+    source.buffer = decodedAudio;
+    source.playbackRate.value = playbackRate;
+    gain.gain.value = Math.max(0, Math.min(1, volume));
+    source.connect(gain);
+    gain.connect(context.destination);
+    this.activeAudioSource = source;
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        window.clearTimeout(playbackTimeoutId);
+        source.onended = null;
+        source.disconnect();
+        gain.disconnect();
+        if (this.activeAudioSource === source) {
+          this.activeAudioSource = null;
+        }
+        this.cancelHostedPlayback = null;
+        if (requestId !== this.requestId) {
+          resolve();
+        } else if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+      const playbackTimeoutId = window.setTimeout(
+        () => finish(new Error('Web Audio playback did not finish.')),
+        Math.max(20000, (decodedAudio.duration / playbackRate) * 1000 + 5000),
+      );
+
+      this.cancelHostedPlayback = () => {
+        try {
+          source.stop();
+        } catch {
+          // A source that already ended can be treated as cancelled.
+        }
+        finish();
+      };
+      source.onended = () => finish();
+      try {
+        source.start(0);
+      } catch {
+        finish(new Error('Web Audio playback could not start.'));
+      }
+    });
+  }
+
+  private playHostedAudioWithElement(blob: Blob, options: TTSOptions, requestId: number): Promise<void> {
     const audio = this.audioElement;
     if (!audio) {
       return Promise.reject(new Error('Hosted audio playback is unavailable on this device.'));
@@ -401,6 +541,7 @@ export class TTSService {
     this.requestId += 1;
     this.cancelHostedPlayback?.();
     this.cancelHostedPlayback = null;
+    this.activeAudioSource = null;
     if (this.audioElement) {
       this.audioElement.pause();
       this.audioElement.currentTime = 0;


### PR DESCRIPTION
## What changed

- unlock a persistent Web Audio context during the user's tap on iPhone
- decode and play the delayed hosted MP3 through Web Audio
- preserve the existing HTML audio and browser speech fallbacks for desktop and older webviews
- add inline playback hints for iOS
- add a regression test for suspended mobile audio contexts and delayed playback

## Root cause

iOS does not reliably preserve an HTML audio autoplay grant through the asynchronous AI and hosted TTS round trip. Desktop browsers accepted the delayed playback, while iPhone Safari could silently block it.

## Validation

- 9 project test files passed (38 tests)
- focused voice/hands-free tests passed (5 tests)
- no ESLint errors in touched files
- no TypeScript errors in touched files
- production Vite build passed