### PR TITLE
Fix iPhone Hyper AI audio routing

### DIFF
--- a/src/components/VoiceChatModal.test.tsx
+++ b/src/components/VoiceChatModal.test.tsx
@@ -9,7 +9,9 @@ const mocks = vi.hoisted(() => ({
   prepare: vi.fn(() => Promise.resolve()),
   speak: vi.fn(() => Promise.resolve()),
   stop: vi.fn(),
-  unlock: vi.fn(),
+  unlock: vi.fn(() => Promise.resolve()),
+  prepareForListening: vi.fn(),
+  releaseAudioSession: vi.fn(),
 }));
 
 vi.mock('../services/hyperAi', () => ({
@@ -33,6 +35,8 @@ vi.mock('../services/tts', () => ({
     speak: mocks.speak,
     stop: mocks.stop,
     unlock: mocks.unlock,
+    prepareForListening: mocks.prepareForListening,
+    releaseAudioSession: mocks.releaseAudioSession,
   },
 }));
 
@@ -81,8 +85,9 @@ describe('VoiceChatModal hands-free conversation', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Start conversation' }));
     const recognition = MockSpeechRecognition.current;
-    expect(recognition?.start).toHaveBeenCalledTimes(1);
-    expect(mocks.unlock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(recognition?.start).toHaveBeenCalledTimes(1));
+    expect(mocks.unlock).toHaveBeenCalledWith(true);
+    expect(mocks.prepareForListening).toHaveBeenCalledTimes(1);
 
     act(() => {
       recognition?.onresult?.({ results: [[{ transcript: 'What changed nearby?' }]] });

--- a/src/components/VoiceChatModal.tsx
+++ b/src/components/VoiceChatModal.tsx
@@ -407,6 +407,7 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
     }
 
     try {
+      ttsService.prepareForListening();
       isListeningRef.current = true;
       setVoiceState('recording');
       recognition.start();
@@ -417,10 +418,12 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
   };
 
   const startHandsFreeConversation = () => {
-    ttsService.unlock();
     handsFreeRef.current = true;
     setIsHandsFreeMode(true);
-    beginListening();
+    // On iPhone, activate the speaker from this direct tap before handing the
+    // audio session to speech recognition. The short tone also confirms that
+    // sound is routed correctly before the first AI response.
+    void ttsService.unlock(true).finally(() => beginListening());
   };
 
   const stopHandsFreeConversation = () => {
@@ -433,6 +436,7 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
     }
     recognitionRef.current?.abort();
     ttsService.stop();
+    ttsService.releaseAudioSession();
     setVoiceState('idle');
   };
 

--- a/src/services/tts.test.ts
+++ b/src/services/tts.test.ts
@@ -26,6 +26,7 @@ class TestAudio {
   onerror: (() => void) | null = null;
   setAttribute = vi.fn();
   pause = vi.fn();
+  load = vi.fn();
   play = vi.fn(() => {
     void Promise.resolve().then(() => this.onended?.());
     return Promise.resolve();
@@ -188,7 +189,7 @@ describe('TTSService', () => {
     });
 
     const service = new TTSService();
-    service.unlock();
+    await service.unlock();
     await service.speak('This should play on an iPhone.', { speed: 1.1, volume: 0.8 });
 
     expect(decodeAudioData).toHaveBeenCalledTimes(1);
@@ -196,5 +197,25 @@ describe('TTSService', () => {
     expect(sources[1].playbackRate.value).toBe(1.1);
     expect(sources[1].start).toHaveBeenCalledWith(0);
     expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('uses the iPhone media route and switches the Safari audio session to playback', async () => {
+    const audioBlob = new Blob(['mp3-data'], { type: 'audio/mpeg' });
+    invokeFunction.mockResolvedValue({ data: audioBlob, error: null });
+    const audioSession = { type: 'ambient' };
+    Object.defineProperty(window.navigator, 'userAgent', {
+      configurable: true,
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)',
+    });
+    Object.defineProperty(window.navigator, 'audioSession', {
+      configurable: true,
+      value: audioSession,
+    });
+
+    const service = new TTSService();
+    await service.speak('Use the iPhone speaker.');
+
+    expect(audioSession.type).toBe('playback');
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -1,4 +1,4 @@
-/* global HTMLAudioElement, AudioBufferSourceNode, AudioContext, Blob, URL, Window */
+/* global HTMLAudioElement, AudioBufferSourceNode, AudioContext, Blob, Navigator, URL, Window */
 import { supabase } from '../lib/supabase';
 
 export interface TTSOptions {
@@ -26,9 +26,25 @@ const BINARY_AUDIO_CONTENT_TYPE = 'application/octet-stream';
 const SILENT_AUDIO_DATA_URI = 'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQQAAAA=';
 type BrowserVoice = ReturnType<typeof window.speechSynthesis.getVoices>[number];
 type AudioContextConstructor = new () => AudioContext;
+type WebAudioSessionType = 'auto' | 'ambient' | 'playback' | 'play-and-record';
 
 interface AudioWindow extends Window {
   webkitAudioContext?: AudioContextConstructor;
+}
+
+interface NavigatorWithAudioSession extends Navigator {
+  audioSession?: {
+    type: WebAudioSessionType;
+  };
+}
+
+function isAppleMobileDevice(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return /iPad|iPhone|iPod/i.test(navigator.userAgent)
+    || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
 }
 
 function splitForSpeech(text: string): string[] {
@@ -129,9 +145,14 @@ export class TTSService {
     }
   }
 
-  unlock(): void {
+  async unlock(playConfirmationTone = false): Promise<void> {
     this.speechSynthesis?.resume();
     void this.speechSynthesis?.getVoices();
+
+    // Safari defaults Web Audio to an ambient session, which is inaudible
+    // when an iPhone's silent switch is on. A playback session uses the media
+    // speaker route and survives the async AI/TTS request that follows.
+    this.prepareForPlayback();
 
     // iOS does not reliably preserve an HTMLMediaElement autoplay grant across
     // the async AI/TTS round trip. Resume Web Audio during the direct tap and
@@ -143,7 +164,10 @@ export class TTSService {
         source.buffer = context.createBuffer(1, 1, context.sampleRate || 44100);
         source.connect(context.destination);
         source.start(0);
-        void context.resume().catch(() => undefined);
+        await context.resume().catch(() => undefined);
+        if (playConfirmationTone && context.state === 'running') {
+          await this.playActivationTone(context);
+        }
       } catch {
         // The unlocked HTML audio element below remains the compatibility path.
       }
@@ -159,11 +183,75 @@ export class TTSService {
     audio.src = SILENT_AUDIO_DATA_URI;
     const unlockAttempt = audio.play();
     if (unlockAttempt) {
-      void unlockAttempt.then(() => {
+      await unlockAttempt.then(() => {
         audio.pause();
         audio.currentTime = 0;
       }).catch(() => undefined);
     }
+  }
+
+  prepareForListening(): void {
+    this.setAudioSessionType('play-and-record');
+  }
+
+  prepareForPlayback(): void {
+    this.setAudioSessionType('playback');
+  }
+
+  releaseAudioSession(): void {
+    this.setAudioSessionType('auto');
+  }
+
+  private setAudioSessionType(type: WebAudioSessionType): void {
+    if (typeof navigator === 'undefined') {
+      return;
+    }
+
+    try {
+      const audioSession = (navigator as NavigatorWithAudioSession).audioSession;
+      if (audioSession) {
+        audioSession.type = type;
+      }
+    } catch {
+      // AudioSession is experimental; all other playback paths still work.
+    }
+  }
+
+  private playActivationTone(context: AudioContext): Promise<void> {
+    return new Promise((resolve) => {
+      try {
+        const oscillator = context.createOscillator();
+        const gain = context.createGain();
+        const now = context.currentTime;
+        oscillator.type = 'sine';
+        oscillator.frequency.setValueAtTime(660, now);
+        oscillator.frequency.exponentialRampToValueAtTime(880, now + 0.09);
+        gain.gain.setValueAtTime(0.0001, now);
+        gain.gain.exponentialRampToValueAtTime(0.075, now + 0.015);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.1);
+        oscillator.connect(gain);
+        gain.connect(context.destination);
+
+        let settled = false;
+        const finish = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          window.clearTimeout(timeoutId);
+          oscillator.onended = null;
+          oscillator.disconnect();
+          gain.disconnect();
+          resolve();
+        };
+        const timeoutId = window.setTimeout(finish, 250);
+        oscillator.onended = finish;
+        oscillator.start(now);
+        oscillator.stop(now + 0.11);
+      } catch {
+        resolve();
+      }
+    });
   }
 
   async prepare(): Promise<void> {
@@ -199,6 +287,7 @@ export class TTSService {
     }
 
     this.stop();
+    this.prepareForPlayback();
     const requestId = this.requestId;
 
     try {
@@ -271,6 +360,20 @@ export class TTSService {
   }
 
   private async playHostedAudio(blob: Blob, options: TTSOptions, requestId: number): Promise<void> {
+    // All iPhone browsers use WebKit. HTML media uses the media speaker route
+    // more reliably than Web Audio after speech recognition has used the mic.
+    if (isAppleMobileDevice() && this.audioElement) {
+      try {
+        await this.playHostedAudioWithElement(blob, options, requestId);
+        return;
+      } catch {
+        if (requestId !== this.requestId) {
+          return;
+        }
+        // Keep Web Audio as a second hosted-audio path on older iOS versions.
+      }
+    }
+
     if (this.audioContext) {
       try {
         await this.playHostedAudioWithWebAudio(blob, options, requestId);
@@ -375,6 +478,7 @@ export class TTSService {
     audio.volume = Math.max(0, Math.min(1, volume));
     audio.playbackRate = Math.max(0.8, Math.min(1.2, speed));
     audio.src = objectUrl;
+    audio.load?.();
 
     return new Promise((resolve, reject) => {
       let settled = false;


### PR DESCRIPTION
## What changed
- switch Safari to a playback audio session while Hyper AI speaks
- switch to play-and-record only while speech recognition listens
- prefer HTML media playback for hosted MP3 audio on iPhone/WebKit
- play a short activation tone from the Start conversation tap
- reset the audio session when the conversation ends

## Root cause
iPhone Safari defaults Web Audio to an ambient session, which can be silent when the hardware mute switch is enabled. Microphone use can also leave the output route in a recording-oriented state.

## Validation
- 39 tests passed
- touched-file ESLint: 0 errors
- production Vite build succeeded