### PR TITLE
Fix mobile AI voice playback end to end

### DIFF
--- a/src/components/VoiceChatModal.css
+++ b/src/components/VoiceChatModal.css
@@ -390,6 +390,7 @@
 
 .ai-assistant-controls {
   display: flex;
+  flex-wrap: wrap;
   flex: 0 0 auto;
   align-items: center;
   gap: 8px;
@@ -398,7 +399,8 @@
 
 .ai-voice-control,
 .ai-audio-toggle,
-.ai-stop-speaking {
+.ai-stop-speaking,
+.ai-test-sound {
   min-height: 38px;
   border: 1px solid rgba(112, 101, 240, 0.14);
   color: #555b67;
@@ -436,6 +438,16 @@
   border-radius: 999px;
 }
 
+.ai-test-sound {
+  padding: 0 12px;
+  border-radius: 999px;
+}
+
+.ai-test-sound:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .ai-assistant-disclaimer {
   flex: 0 0 auto;
   margin: 15px 0 0;
@@ -451,7 +463,8 @@
 .ai-assistant-suggestions button:hover,
 .ai-voice-control:hover,
 .ai-audio-toggle:hover,
-.ai-stop-speaking:hover {
+.ai-stop-speaking:hover,
+.ai-test-sound:hover {
   border-color: rgba(112, 101, 240, 0.32);
   background-color: rgba(255, 255, 255, 0.72);
 }

--- a/src/components/VoiceChatModal.test.tsx
+++ b/src/components/VoiceChatModal.test.tsx
@@ -1,3 +1,4 @@
+/* global Event */
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   unlock: vi.fn(() => Promise.resolve()),
   prepareForListening: vi.fn(),
   releaseAudioSession: vi.fn(),
+  resetAudioOutput: vi.fn(),
 }));
 
 vi.mock('../services/hyperAi', () => ({
@@ -37,6 +39,7 @@ vi.mock('../services/tts', () => ({
     unlock: mocks.unlock,
     prepareForListening: mocks.prepareForListening,
     releaseAudioSession: mocks.releaseAudioSession,
+    resetAudioOutput: mocks.resetAudioOutput,
   },
 }));
 
@@ -121,5 +124,32 @@ describe('VoiceChatModal hands-free conversation', () => {
       'The voice response is ready.',
       expect.objectContaining({ volume: 1 }),
     ));
+  });
+
+  it('offers a direct sound test that unlocks and plays from the user tap', async () => {
+    render(<VoiceChatModal isOpen onClose={vi.fn()} userLocation={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test sound' }));
+
+    expect(mocks.unlock).toHaveBeenCalledWith(true);
+    await waitFor(() => expect(mocks.speak).toHaveBeenCalledWith(
+      'Hyper AI sound is working.',
+      expect.objectContaining({ volume: 1 }),
+    ));
+  });
+
+  it('stops hands-free mode when the app is backgrounded and resets audio after resume', async () => {
+    render(<VoiceChatModal isOpen onClose={vi.fn()} userLocation={null} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Start conversation' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'End conversation' })).toBeVisible());
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    fireEvent(document, new Event('visibilitychange'));
+    expect(screen.getByRole('button', { name: 'Start conversation' })).toBeVisible();
+    expect(mocks.releaseAudioSession).toHaveBeenCalled();
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    fireEvent(window, new Event('pageshow'));
+    expect(mocks.resetAudioOutput).toHaveBeenCalled();
   });
 });

--- a/src/components/VoiceChatModal.tsx
+++ b/src/components/VoiceChatModal.tsx
@@ -440,6 +440,41 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
     setVoiceState('idle');
   };
 
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const resetAfterResume = () => {
+      if (document.visibilityState === 'visible') {
+        ttsService.resetAudioOutput();
+      }
+    };
+    const pauseConversation = () => {
+      if (document.visibilityState !== 'hidden') {
+        return;
+      }
+      handsFreeRef.current = false;
+      setIsHandsFreeMode(false);
+      isListeningRef.current = false;
+      if (restartTimerRef.current !== null) {
+        window.clearTimeout(restartTimerRef.current);
+        restartTimerRef.current = null;
+      }
+      recognitionRef.current?.abort();
+      ttsService.stop();
+      ttsService.releaseAudioSession();
+      setVoiceState('idle');
+    };
+
+    document.addEventListener('visibilitychange', pauseConversation);
+    window.addEventListener('pageshow', resetAfterResume);
+    return () => {
+      document.removeEventListener('visibilitychange', pauseConversation);
+      window.removeEventListener('pageshow', resetAfterResume);
+    };
+  }, [isOpen]);
+
   const processTranscript = async (transcriptText: string) => {
     const cleanedText = transcriptText.trim();
     if (!cleanedText) {
@@ -510,6 +545,25 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
     setVoiceState('idle');
     if (handsFreeRef.current) {
       scheduleListeningRestart();
+    }
+  };
+
+  const testSound = async () => {
+    stopHandsFreeConversation();
+    setErrorMessage('');
+    setVoiceState('speaking');
+    try {
+      await ttsService.unlock(true);
+      await ttsService.speak('Hyper AI sound is working.', {
+        speed: 1.02,
+        pitch: 1.02,
+        volume: 1,
+      });
+      setVoiceState('idle');
+    } catch (error) {
+      console.error('Sound test failed:', error);
+      setErrorMessage('Sound is blocked. Turn up media volume, disable Silent Mode, then tap Test sound again.');
+      setVoiceState('error');
     }
   };
 
@@ -747,6 +801,15 @@ const VoiceChatModal: React.FC<VoiceChatModalProps> = ({
               aria-label={`${isTTSEnabled ? 'Disable' : 'Enable'} voice responses`}
             >
               {isTTSEnabled ? <Volume2 size={17} /> : <VolumeX size={17} />}
+            </button>
+
+            <button
+              type="button"
+              className="ai-test-sound"
+              onClick={() => void testSound()}
+              disabled={isProcessing || isSpeaking}
+            >
+              Test sound
             </button>
 
             {isSpeaking && (

--- a/src/services/tts.test.ts
+++ b/src/services/tts.test.ts
@@ -14,6 +14,7 @@ vi.mock('../lib/supabase', () => ({
 import { TTSService } from './tts';
 
 type TestVoice = ReturnType<typeof window.speechSynthesis.getVoices>[number];
+const createdAudioElements: TestAudio[] = [];
 
 class TestAudio {
   preload = '';
@@ -24,6 +25,9 @@ class TestAudio {
   currentTime = 0;
   onended: (() => void) | null = null;
   onerror: (() => void) | null = null;
+  onplaying: (() => void) | null = null;
+  onloadedmetadata: (() => void) | null = null;
+  duration = 0.1;
   setAttribute = vi.fn();
   pause = vi.fn();
   load = vi.fn();
@@ -31,11 +35,16 @@ class TestAudio {
     void Promise.resolve().then(() => this.onended?.());
     return Promise.resolve();
   });
+
+  constructor() {
+    createdAudioElements.push(this);
+  }
 }
 
 describe('TTSService', () => {
   beforeEach(() => {
     invokeFunction.mockReset();
+    createdAudioElements.length = 0;
     vi.stubGlobal('URL', {
       ...URL,
       createObjectURL: vi.fn(() => 'blob:hosted-voice'),
@@ -54,7 +63,12 @@ describe('TTSService', () => {
 
   it('plays hosted neural audio and caches repeated replies', async () => {
     // supabase-js preserves binary function responses as octet-stream Blobs.
-    const audioBlob = new Blob(['mp3-data'], { type: 'application/octet-stream' });
+    const audioBlob = new Blob([
+      new Uint8Array([
+        0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+        0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+      ]),
+    ], { type: 'application/octet-stream' });
     invokeFunction.mockResolvedValue({ data: audioBlob, error: null });
     const browserSpeak = vi.fn();
     Object.defineProperty(window, 'speechSynthesis', {
@@ -79,7 +93,7 @@ describe('TTSService', () => {
     });
     expect(browserSpeak).not.toHaveBeenCalled();
     expect(URL.createObjectURL).toHaveBeenCalledTimes(2);
-    expect((vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob).type).toBe('audio/mpeg');
+    expect((vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob).type).toBe('audio/wav');
     expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
   });
 
@@ -217,5 +231,39 @@ describe('TTSService', () => {
 
     expect(audioSession.type).toBe('playback');
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts the iOS media unlock synchronously before waiting for Web Audio', async () => {
+    let finishResume: (() => void) | undefined;
+    const resumePromise = new Promise<void>((resolve) => {
+      finishResume = resolve;
+    });
+
+    class DelayedAudioContext {
+      state: AudioContextState = 'suspended';
+      sampleRate = 44100;
+      destination = {} as AudioDestinationNode;
+      resume = vi.fn(() => resumePromise.then(() => {
+        this.state = 'running';
+      }));
+      close = vi.fn(async () => undefined);
+      createBuffer = vi.fn(() => ({} as AudioBuffer));
+      createBufferSource = vi.fn(() => ({
+        buffer: null,
+        connect: vi.fn(),
+        start: vi.fn(),
+      } as unknown as AudioBufferSourceNode));
+    }
+    Object.defineProperty(window, 'AudioContext', {
+      configurable: true,
+      value: DelayedAudioContext,
+    });
+
+    const service = new TTSService();
+    const unlockPromise = service.unlock();
+
+    expect(createdAudioElements[0].play).toHaveBeenCalledTimes(1);
+    finishResume?.();
+    await unlockPromise;
   });
 });

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -1,4 +1,4 @@
-/* global HTMLAudioElement, AudioBufferSourceNode, AudioContext, Blob, Navigator, URL, Window */
+/* global HTMLAudioElement, AudioBufferSourceNode, AudioContext, Blob, FileReader, Navigator, URL, Window */
 import { supabase } from '../lib/supabase';
 
 export interface TTSOptions {
@@ -24,6 +24,8 @@ const MAX_SPEECH_CHUNK_LENGTH = 220;
 const MAX_AUDIO_CACHE_ENTRIES = 16;
 const BINARY_AUDIO_CONTENT_TYPE = 'application/octet-stream';
 const SILENT_AUDIO_DATA_URI = 'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQQAAAA=';
+const HOSTED_AUDIO_START_TIMEOUT_MS = 8000;
+const HOSTED_AUDIO_MAX_PLAYBACK_MS = 60000;
 type BrowserVoice = ReturnType<typeof window.speechSynthesis.getVoices>[number];
 type AudioContextConstructor = new () => AudioContext;
 type WebAudioSessionType = 'auto' | 'ambient' | 'playback' | 'play-and-record';
@@ -45,6 +47,35 @@ function isAppleMobileDevice(): boolean {
 
   return /iPad|iPhone|iPod/i.test(navigator.userAgent)
     || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}
+
+function detectAudioMimeType(bytes: Uint8Array): 'audio/mpeg' | 'audio/wav' | null {
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+    bytes[8] === 0x57 && bytes[9] === 0x41 && bytes[10] === 0x56 && bytes[11] === 0x45
+  ) {
+    return 'audio/wav';
+  }
+  if (bytes.length >= 3 && bytes[0] === 0x49 && bytes[1] === 0x44 && bytes[2] === 0x33) {
+    return 'audio/mpeg';
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0) {
+    return 'audio/mpeg';
+  }
+  return null;
+}
+
+function readBlobArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  if (typeof blob.arrayBuffer === 'function') {
+    return blob.arrayBuffer();
+  }
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error || new Error('Could not read hosted audio.'));
+    reader.readAsArrayBuffer(blob);
+  });
 }
 
 function splitForSpeech(text: string): string[] {
@@ -137,12 +168,18 @@ export class TTSService {
     if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
       this.speechSynthesis = window.speechSynthesis;
     }
-    if (typeof window !== 'undefined' && typeof window.Audio === 'function') {
-      this.audioElement = new window.Audio();
-      this.audioElement.preload = 'auto';
-      this.audioElement.setAttribute?.('playsinline', '');
-      this.audioElement.setAttribute?.('webkit-playsinline', '');
+    this.audioElement = this.createAudioElement();
+  }
+
+  private createAudioElement(): HTMLAudioElement | null {
+    if (typeof window === 'undefined' || typeof window.Audio !== 'function') {
+      return null;
     }
+    const audio = new window.Audio();
+    audio.preload = 'auto';
+    audio.setAttribute?.('playsinline', '');
+    audio.setAttribute?.('webkit-playsinline', '');
+    return audio;
   }
 
   async unlock(playConfirmationTone = false): Promise<void> {
@@ -157,14 +194,33 @@ export class TTSService {
     // iOS does not reliably preserve an HTMLMediaElement autoplay grant across
     // the async AI/TTS round trip. Resume Web Audio during the direct tap and
     // keep that context available for the delayed hosted response.
+    // Start every permission-sensitive operation before the first await. iOS
+    // only treats this synchronous portion as part of the user's tap.
+    const audio = this.audioElement || this.createAudioElement();
+    this.audioElement = audio;
+    let mediaUnlockAttempt: Promise<void> = Promise.resolve();
+    if (audio) {
+      audio.muted = false;
+      audio.src = SILENT_AUDIO_DATA_URI;
+      try {
+        const attempt = audio.play();
+        if (attempt) {
+          mediaUnlockAttempt = attempt.then(() => undefined).catch(() => undefined);
+        }
+      } catch {
+        // Web Audio and browser speech remain available as compatibility paths.
+      }
+    }
+
     const context = this.getOrCreateAudioContext();
+    const contextResumeAttempt = context?.resume().catch(() => undefined) || Promise.resolve();
     if (context) {
       try {
         const source = context.createBufferSource();
         source.buffer = context.createBuffer(1, 1, context.sampleRate || 44100);
         source.connect(context.destination);
         source.start(0);
-        await context.resume().catch(() => undefined);
+        await contextResumeAttempt;
         if (playConfirmationTone && context.state === 'running') {
           await this.playActivationTone(context);
         }
@@ -173,21 +229,23 @@ export class TTSService {
       }
     }
 
-    const audio = this.audioElement;
     if (!audio) {
       return;
     }
-    // The file itself is silent. Keep the element unmuted so iOS/Safari and
-    // desktop autoplay policies register this user gesture for later speech.
-    audio.muted = false;
-    audio.src = SILENT_AUDIO_DATA_URI;
-    const unlockAttempt = audio.play();
-    if (unlockAttempt) {
-      await unlockAttempt.then(() => {
-        audio.pause();
-        audio.currentTime = 0;
-      }).catch(() => undefined);
+    await mediaUnlockAttempt;
+    audio.pause();
+    audio.currentTime = 0;
+  }
+
+  resetAudioOutput(): void {
+    this.stop();
+    const previousContext = this.audioContext;
+    this.audioContext = null;
+    if (previousContext && previousContext.state !== 'closed') {
+      void previousContext.close().catch(() => undefined);
     }
+    this.audioElement = this.createAudioElement();
+    this.releaseAudioSession();
   }
 
   prepareForListening(): void {
@@ -339,9 +397,16 @@ export class TTSService {
 
       // Supabase needs an octet-stream response to preserve the binary body.
       // Restore the real MIME type before handing the object URL to browsers.
-      const audio = data.type === BINARY_AUDIO_CONTENT_TYPE
-        ? new Blob([data], { type: 'audio/mpeg' })
-        : data;
+      let audio = data;
+      if (data.type === BINARY_AUDIO_CONTENT_TYPE) {
+        const audioBuffer = await readBlobArrayBuffer(data);
+        const signature = new Uint8Array(audioBuffer, 0, Math.min(12, audioBuffer.byteLength));
+        const mimeType = detectAudioMimeType(signature);
+        if (!mimeType) {
+          throw new Error('Hosted voice returned an unsupported audio format.');
+        }
+        audio = new Blob([audioBuffer], { type: mimeType });
+      }
 
       this.audioCache.set(text, audio);
       while (this.audioCache.size > MAX_AUDIO_CACHE_ENTRIES) {
@@ -405,7 +470,7 @@ export class TTSService {
       throw new Error('Web Audio playback is still suspended.');
     }
 
-    const decodedAudio = await context.decodeAudioData(await blob.arrayBuffer());
+    const decodedAudio = await context.decodeAudioData(await readBlobArrayBuffer(blob));
     if (requestId !== this.requestId) {
       return;
     }
@@ -482,6 +547,20 @@ export class TTSService {
 
     return new Promise((resolve, reject) => {
       let settled = false;
+      let playbackTimeoutId = window.setTimeout(
+        () => finish(new Error('Hosted voice playback did not start.')),
+        HOSTED_AUDIO_START_TIMEOUT_MS,
+      );
+      const armPlaybackTimeout = () => {
+        window.clearTimeout(playbackTimeoutId);
+        const durationMs = Number.isFinite(audio.duration) && audio.duration > 0
+          ? (audio.duration / audio.playbackRate) * 1000 + 5000
+          : 30000;
+        playbackTimeoutId = window.setTimeout(
+          () => finish(new Error('Hosted voice playback did not finish.')),
+          Math.min(HOSTED_AUDIO_MAX_PLAYBACK_MS, Math.max(10000, durationMs)),
+        );
+      };
       const finish = (error?: Error) => {
         if (settled) {
           return;
@@ -491,6 +570,8 @@ export class TTSService {
         window.clearTimeout(playbackTimeoutId);
         audio.onended = null;
         audio.onerror = null;
+        audio.onplaying = null;
+        audio.onloadedmetadata = null;
         URL.revokeObjectURL(objectUrl);
         if (requestId !== this.requestId) {
           resolve();
@@ -500,14 +581,11 @@ export class TTSService {
           resolve();
         }
       };
-      const playbackTimeoutId = window.setTimeout(
-        () => finish(new Error('Hosted voice playback did not finish.')),
-        Math.max(20000, blob.size * 3),
-      );
-
       this.cancelHostedPlayback = () => finish();
       audio.onended = () => finish();
       audio.onerror = () => finish(new Error('Hosted voice playback failed.'));
+      audio.onplaying = armPlaybackTimeout;
+      audio.onloadedmetadata = armPlaybackTimeout;
       const playAttempt = audio.play();
       if (playAttempt) {
         void playAttempt.catch(() => finish(new Error('Hosted voice playback was blocked.')));

--- a/supabase/functions/_shared/cloudflareAudio.test.ts
+++ b/supabase/functions/_shared/cloudflareAudio.test.ts
@@ -1,0 +1,41 @@
+/* global Response, btoa */
+import { describe, expect, it } from 'vitest';
+
+import { detectAudioMimeType, extractCloudflareAudio } from './cloudflareAudio';
+
+const WAV_BYTES = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+  0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+]);
+
+describe('Cloudflare audio extraction', () => {
+  it('decodes the MeloTTS JSON base64 WAV envelope', async () => {
+    const encoded = btoa(String.fromCharCode(...WAV_BYTES));
+    const response = new Response(JSON.stringify({ result: { audio: encoded } }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await extractCloudflareAudio(response);
+
+    expect(result?.mimeType).toBe('audio/wav');
+    expect(Array.from(result?.bytes || [])).toEqual(Array.from(WAV_BYTES));
+  });
+
+  it('accepts raw MP3 bytes and detects both common MP3 signatures', async () => {
+    const bytes = new Uint8Array([0x49, 0x44, 0x33, 0x04, 0x00]);
+    const response = new Response(bytes, { headers: { 'content-type': 'audio/mpeg' } });
+
+    expect((await extractCloudflareAudio(response))?.mimeType).toBe('audio/mpeg');
+    expect(detectAudioMimeType(new Uint8Array([0xff, 0xfb, 0x90, 0x64]))).toBe('audio/mpeg');
+  });
+
+  it('rejects malformed or unsupported provider payloads', async () => {
+    const invalidJson = new Response(JSON.stringify({ result: { audio: 'not audio' } }), {
+      headers: { 'content-type': 'application/json' },
+    });
+    const unknownBytes = new Response(new Uint8Array([1, 2, 3]));
+
+    expect(await extractCloudflareAudio(invalidJson)).toBeNull();
+    expect(await extractCloudflareAudio(unknownBytes)).toBeNull();
+  });
+});

--- a/supabase/functions/_shared/cloudflareAudio.ts
+++ b/supabase/functions/_shared/cloudflareAudio.ts
@@ -1,0 +1,73 @@
+/* global Response, atob */
+export type CloudflareAudioMimeType = 'audio/mpeg' | 'audio/wav';
+
+export interface CloudflareAudio {
+  bytes: Uint8Array;
+  mimeType: CloudflareAudioMimeType;
+}
+
+interface CloudflareAudioEnvelope {
+  result?: {
+    audio?: unknown;
+  };
+}
+
+export function detectAudioMimeType(bytes: Uint8Array): CloudflareAudioMimeType | null {
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+    bytes[8] === 0x57 && bytes[9] === 0x41 && bytes[10] === 0x56 && bytes[11] === 0x45
+  ) {
+    return 'audio/wav';
+  }
+
+  if (
+    bytes.length >= 3 && bytes[0] === 0x49 && bytes[1] === 0x44 && bytes[2] === 0x33
+  ) {
+    return 'audio/mpeg';
+  }
+
+  if (
+    bytes.length >= 2 && bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0
+  ) {
+    return 'audio/mpeg';
+  }
+
+  return null;
+}
+
+function decodeBase64(value: string): Uint8Array | null {
+  try {
+    const normalized = value.replace(/^data:audio\/[\w.+-]+;base64,/i, '').replace(/\s/g, '');
+    if (!normalized || normalized.length % 4 === 1) {
+      return null;
+    }
+    const decoded = atob(normalized);
+    const bytes = new Uint8Array(decoded.length);
+    for (let index = 0; index < decoded.length; index += 1) {
+      bytes[index] = decoded.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+export async function extractCloudflareAudio(response: Response): Promise<CloudflareAudio | null> {
+  const contentType = (response.headers.get('content-type') || '').toLowerCase();
+
+  if (contentType.includes('application/json')) {
+    const payload = await response.json().catch(() => null) as CloudflareAudioEnvelope | null;
+    const encodedAudio = payload?.result?.audio;
+    if (typeof encodedAudio !== 'string') {
+      return null;
+    }
+    const bytes = decodeBase64(encodedAudio);
+    const mimeType = bytes ? detectAudioMimeType(bytes) : null;
+    return bytes && bytes.byteLength > 0 && mimeType ? { bytes, mimeType } : null;
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const mimeType = detectAudioMimeType(bytes);
+  return bytes.byteLength > 0 && mimeType ? { bytes, mimeType } : null;
+}

--- a/supabase/functions/hyper-tts/index.ts
+++ b/supabase/functions/hyper-tts/index.ts
@@ -1,6 +1,11 @@
 /* global Deno, Request, Response, AbortController, fetch, TextEncoder, crypto, DOMException */
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.76.1';
 
+import {
+  extractCloudflareAudio,
+  type CloudflareAudioMimeType,
+} from '../_shared/cloudflareAudio.ts';
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -17,8 +22,6 @@ const audioHeaders = {
   // supabase-js currently treats only application/octet-stream and PDFs as
   // binary responses. Returning audio/mpeg makes it decode the MP3 as text.
   'Content-Type': 'application/octet-stream',
-  'Content-Disposition': 'inline; filename="hyper-ai.mp3"',
-  'X-Hyper-Audio-Type': 'audio/mpeg',
   'X-Content-Type-Options': 'nosniff',
 };
 const MODEL = '@cf/myshell-ai/melotts';
@@ -29,7 +32,12 @@ const CACHE_TTL_MS = 30 * 60 * 1000;
 const MAX_CACHE_ENTRIES = 80;
 const SUPPORTED_LANGUAGES = new Set(['en', 'es', 'fr', 'zh', 'ja', 'ko']);
 const requestWindows = new Map<string, number[]>();
-const audioCache = new Map<string, { audio: Uint8Array; expiresAt: number }>();
+const PROVIDER_ATTEMPTS = 3;
+const audioCache = new Map<string, {
+  audio: Uint8Array;
+  mimeType: CloudflareAudioMimeType;
+  expiresAt: number;
+}>();
 
 function json(body: Record<string, unknown>, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
@@ -72,7 +80,7 @@ async function createCacheKey(userId: string, text: string, language: string): P
     .join('');
 }
 
-function getCachedAudio(key: string): Uint8Array | null {
+function getCachedAudio(key: string): { audio: Uint8Array; mimeType: CloudflareAudioMimeType } | null {
   const cached = audioCache.get(key);
   if (!cached) {
     return null;
@@ -83,11 +91,11 @@ function getCachedAudio(key: string): Uint8Array | null {
   }
   audioCache.delete(key);
   audioCache.set(key, cached);
-  return cached.audio;
+  return { audio: cached.audio, mimeType: cached.mimeType };
 }
 
-function cacheAudio(key: string, audio: Uint8Array): void {
-  audioCache.set(key, { audio, expiresAt: Date.now() + CACHE_TTL_MS });
+function cacheAudio(key: string, audio: Uint8Array, mimeType: CloudflareAudioMimeType): void {
+  audioCache.set(key, { audio, mimeType, expiresAt: Date.now() + CACHE_TTL_MS });
   while (audioCache.size > MAX_CACHE_ENTRIES) {
     const oldestKey = audioCache.keys().next().value as string | undefined;
     if (!oldestKey) {
@@ -97,11 +105,65 @@ function cacheAudio(key: string, audio: Uint8Array): void {
   }
 }
 
-function audioResponse(audio: Uint8Array, cacheStatus: 'HIT' | 'MISS'): Response {
+function audioResponse(
+  audio: Uint8Array,
+  mimeType: CloudflareAudioMimeType,
+  cacheStatus: 'HIT' | 'MISS',
+): Response {
+  const extension = mimeType === 'audio/wav' ? 'wav' : 'mp3';
   return new Response(audio.slice().buffer, {
     status: 200,
-    headers: { ...audioHeaders, 'X-Hyper-TTS-Cache': cacheStatus },
+    headers: {
+      ...audioHeaders,
+      'Content-Disposition': `inline; filename="hyper-ai.${extension}"`,
+      'X-Hyper-Audio-Type': mimeType,
+      'X-Hyper-TTS-Cache': cacheStatus,
+    },
   });
+}
+
+async function requestHostedVoice(
+  accountId: string,
+  apiToken: string,
+  text: string,
+  language: string,
+): Promise<Response> {
+  let lastResponse: Response | null = null;
+
+  for (let attempt = 0; attempt < PROVIDER_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15_000);
+    try {
+      const response = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/ai/run/${MODEL}`,
+        {
+          method: 'POST',
+          signal: controller.signal,
+          headers: {
+            Accept: 'application/json, audio/*',
+            Authorization: `Bearer ${apiToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ prompt: text, lang: language }),
+        },
+      );
+      lastResponse = response;
+      if (response.ok || (response.status !== 429 && response.status < 500)) {
+        return response;
+      }
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (attempt < PROVIDER_ATTEMPTS - 1) {
+      await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+    }
+  }
+
+  if (!lastResponse) {
+    throw new Error('The hosted voice provider did not return a response.');
+  }
+  return lastResponse;
 }
 
 Deno.serve(async (req) => {
@@ -138,29 +200,10 @@ Deno.serve(async (req) => {
     const cacheKey = await createCacheKey(userId, text, language);
     const cached = getCachedAudio(cacheKey);
     if (cached) {
-      return audioResponse(cached, 'HIT');
+      return audioResponse(cached.audio, cached.mimeType, 'HIT');
     }
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 15_000);
-    let response: Response;
-    try {
-      response = await fetch(
-        `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/ai/run/${MODEL}`,
-        {
-          method: 'POST',
-          signal: controller.signal,
-          headers: {
-            Accept: 'audio/mpeg',
-            Authorization: `Bearer ${apiToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ prompt: text, lang: language }),
-        },
-      );
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    const response = await requestHostedVoice(accountId, apiToken, text, language);
 
     if (!response.ok) {
       console.error('Cloudflare MeloTTS request failed', { status: response.status });
@@ -170,18 +213,14 @@ Deno.serve(async (req) => {
       return json({ error: 'The hosted voice service is temporarily unavailable.' }, 502);
     }
 
-    const contentType = response.headers.get('content-type') || '';
-    if (!contentType.toLowerCase().includes('audio/')) {
-      console.error('Cloudflare MeloTTS returned an unexpected response type');
+    const hostedAudio = await extractCloudflareAudio(response);
+    if (!hostedAudio) {
+      console.error('Cloudflare MeloTTS returned invalid audio');
       return json({ error: 'The hosted voice returned an invalid response.' }, 502);
     }
 
-    const audio = new Uint8Array(await response.arrayBuffer());
-    if (audio.byteLength === 0) {
-      return json({ error: 'The hosted voice returned empty audio.' }, 502);
-    }
-    cacheAudio(cacheKey, audio);
-    return audioResponse(audio, 'MISS');
+    cacheAudio(cacheKey, hostedAudio.bytes, hostedAudio.mimeType);
+    return audioResponse(hostedAudio.bytes, hostedAudio.mimeType, 'MISS');
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       return json({ error: 'The hosted voice took too long to respond.' }, 504);


### PR DESCRIPTION
## What changed

- decode Cloudflare MeloTTS JSON/base64 responses into real WAV bytes in the Supabase function
- retry transient Cloudflare provider failures and preserve the detected WAV/MP3 type through the binary Supabase response
- sniff hosted audio bytes in the browser instead of assuming every response is MP3
- unlock HTML media and Web Audio synchronously during the user's tap for iOS autoplay compliance
- reset stale audio elements and contexts when an installed iOS web app resumes
- bound playback timeouts and add a visible **Test sound** control
- retain automatic listening after Hyper AI finishes speaking

## Root cause

MeloTTS returns successful audio as a JSON envelope containing base64-encoded WAV data. The edge function expected a raw `audio/*` response and returned 502, which forced the app onto browser speech synthesis. That fallback appeared to work on desktop but is unreliable on iPhone. The iOS unlock path also awaited Web Audio before calling `HTMLAudioElement.play()`, losing the direct user-gesture authorization.

## Validation

- `vitest run src supabase/functions/_shared` — 45 tests passed
- focused edited-file ESLint — 0 errors
- `vite build` — passed
- Supabase `hyper-tts` version 7 deployed and ACTIVE

The repository-wide TypeScript check still reports the existing unrelated unused-code and old test-matcher typing backlog.
